### PR TITLE
Add interactive lobby design playground

### DIFF
--- a/quiz-setup-playground.html
+++ b/quiz-setup-playground.html
@@ -1,0 +1,940 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Game Night Lobby — Design Playground</title>
+<style>
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+  html { font-size: 15px; }
+  body {
+    font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
+    background: #08070f;
+    color: #e0e0e8;
+    display: grid;
+    grid-template-columns: 320px 1fr;
+    grid-template-rows: auto 1fr auto;
+    height: 100vh;
+    overflow: hidden;
+  }
+
+  /* ── Top bar ── */
+  .topbar {
+    grid-column: 1 / -1;
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 0.6rem 1.2rem;
+    background: rgba(255,255,255,0.03);
+    border-bottom: 1px solid rgba(255,255,255,0.06);
+  }
+  .topbar-title {
+    font-size: 0.85rem; font-weight: 800; letter-spacing: 0.06em;
+    text-transform: uppercase;
+    background: linear-gradient(135deg, #ff8906, #00eaff);
+    -webkit-background-clip: text; -webkit-text-fill-color: transparent;
+    background-clip: text;
+  }
+  .topbar-sub { font-size: 0.72rem; color: #555770; }
+
+  /* ── Controls panel ── */
+  .controls {
+    overflow-y: auto; padding: 1rem;
+    border-right: 1px solid rgba(255,255,255,0.06);
+    display: flex; flex-direction: column; gap: 0.4rem;
+    scrollbar-width: thin; scrollbar-color: rgba(255,255,255,0.1) transparent;
+  }
+  .controls::-webkit-scrollbar { width: 5px; }
+  .controls::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.1); border-radius: 3px; }
+
+  .section-label {
+    font-size: 0.62rem; font-weight: 800; text-transform: uppercase;
+    letter-spacing: 0.14em; color: #555770;
+    padding: 0.6rem 0 0.25rem; border-top: 1px solid rgba(255,255,255,0.04);
+  }
+  .section-label:first-child { border-top: none; padding-top: 0; }
+
+  .control-group { display: flex; flex-direction: column; gap: 0.2rem; }
+  .control-label {
+    font-size: 0.72rem; font-weight: 700; color: #a7a9be;
+    display: flex; justify-content: space-between; align-items: center;
+  }
+  .control-value { color: #ff8906; font-family: 'SF Mono', 'Fira Code', monospace; font-size: 0.68rem; }
+
+  /* Slider */
+  input[type="range"] {
+    -webkit-appearance: none; width: 100%; height: 4px;
+    background: rgba(255,255,255,0.08); border-radius: 2px; outline: none;
+  }
+  input[type="range"]::-webkit-slider-thumb {
+    -webkit-appearance: none; width: 14px; height: 14px;
+    background: #ff8906; border-radius: 50%; cursor: pointer;
+    box-shadow: 0 0 8px rgba(255,137,6,0.5);
+  }
+
+  /* Toggle chips */
+  .chip-row { display: flex; flex-wrap: wrap; gap: 0.3rem; }
+  .chip-btn {
+    padding: 0.3rem 0.6rem; font-size: 0.72rem; font-weight: 700;
+    background: rgba(255,255,255,0.04); color: #a7a9be;
+    border: 1.5px solid rgba(255,255,255,0.08); border-radius: 999px;
+    cursor: pointer; transition: all 0.15s;
+  }
+  .chip-btn:hover { background: rgba(255,255,255,0.08); color: #fff; }
+  .chip-btn.active {
+    background: rgba(255,137,6,0.15); border-color: rgba(255,137,6,0.5);
+    color: #ff8906; box-shadow: 0 0 10px rgba(255,137,6,0.15);
+  }
+
+  /* Preset buttons */
+  .preset-row { display: flex; gap: 0.35rem; flex-wrap: wrap; }
+  .preset-btn {
+    flex: 1; min-width: 80px; padding: 0.55rem 0.4rem;
+    font-size: 0.7rem; font-weight: 800; text-align: center;
+    background: rgba(127,90,240,0.08); color: #7f5af0;
+    border: 1.5px solid rgba(127,90,240,0.2); border-radius: 0.6rem;
+    cursor: pointer; transition: all 0.2s;
+  }
+  .preset-btn:hover {
+    background: rgba(127,90,240,0.2); border-color: rgba(127,90,240,0.5);
+    transform: translateY(-1px);
+  }
+
+  /* ── Preview frame ── */
+  .preview-wrap {
+    overflow: hidden; position: relative;
+    display: flex; align-items: center; justify-content: center;
+    background: #0f0e17;
+  }
+  .preview-frame {
+    width: 390px; height: 100%; max-height: 844px;
+    position: relative; overflow-y: auto; overflow-x: hidden;
+    border-radius: 0;
+    scrollbar-width: thin; scrollbar-color: rgba(255,255,255,0.08) transparent;
+  }
+  .preview-frame::-webkit-scrollbar { width: 4px; }
+  .preview-frame::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.1); border-radius: 2px; }
+
+  /* Phone bezel toggle */
+  .preview-wrap.phone-bezel .preview-frame {
+    border-radius: 40px;
+    border: 3px solid rgba(255,255,255,0.12);
+    box-shadow: 0 0 60px rgba(0,0,0,0.6), inset 0 0 30px rgba(0,0,0,0.2);
+    max-height: 780px;
+    width: 375px;
+  }
+  .bezel-toggle {
+    position: absolute; top: 0.6rem; right: 0.6rem; z-index: 10;
+    padding: 0.25rem 0.5rem; font-size: 0.65rem; font-weight: 700;
+    background: rgba(0,0,0,0.6); color: #a7a9be;
+    border: 1px solid rgba(255,255,255,0.1); border-radius: 999px;
+    cursor: pointer; transition: all 0.15s;
+  }
+  .bezel-toggle:hover { color: #fff; border-color: rgba(255,255,255,0.3); }
+
+  /* ── Prompt bar ── */
+  .prompt-bar {
+    grid-column: 1 / -1;
+    background: rgba(255,255,255,0.02);
+    border-top: 1px solid rgba(255,255,255,0.06);
+    padding: 0.6rem 1.2rem;
+    display: flex; align-items: flex-start; gap: 0.75rem;
+  }
+  .prompt-text {
+    flex: 1; font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+    font-size: 0.72rem; line-height: 1.5; color: #a7a9be;
+    max-height: 5.5rem; overflow-y: auto;
+    scrollbar-width: thin;
+  }
+  .copy-btn {
+    flex-shrink: 0; padding: 0.4rem 0.9rem;
+    font-size: 0.72rem; font-weight: 800;
+    background: linear-gradient(135deg, #ff8906, #e53170);
+    color: #fff; border: none; border-radius: 0.5rem;
+    cursor: pointer; transition: all 0.15s; white-space: nowrap;
+  }
+  .copy-btn:hover { transform: translateY(-1px); box-shadow: 0 4px 15px rgba(255,137,6,0.3); }
+
+  /* ═══ PREVIEW INTERNALS ═══ */
+
+  .p-body {
+    min-height: 100%; display: flex; flex-direction: column;
+    align-items: center; padding: 1rem 0.85rem 7rem;
+    gap: 0.75rem; position: relative; overflow: hidden;
+  }
+
+  /* Animated bg mesh */
+  .p-bg-mesh::before {
+    content: ''; position: absolute; inset: -50%;
+    pointer-events: none; z-index: 0;
+    animation: pMeshDrift 16s ease-in-out infinite alternate;
+  }
+  @keyframes pMeshDrift {
+    0%   { transform: translate(0, 0) rotate(0deg) scale(1); }
+    50%  { transform: translate(3%, -2%) rotate(1deg) scale(1.02); }
+    100% { transform: translate(-2%, 3%) rotate(-0.5deg) scale(0.98); }
+  }
+
+  .p-body > * { position: relative; z-index: 1; }
+
+  /* Header */
+  .p-header {
+    width: 100%; display: flex; align-items: center; justify-content: space-between;
+    padding: 0.2rem 0;
+  }
+  .p-header-title { font-weight: 900; }
+  .p-header-right { display: flex; align-items: center; gap: 0.35rem; }
+  .p-rules-link {
+    text-decoration: none; font-size: 0.65rem; font-weight: 700;
+    padding: 0.2rem 0.5rem; border-radius: 999px;
+    transition: all 0.2s; cursor: default;
+  }
+  .p-room-chip {
+    padding: 0.25rem 0.6rem; font-weight: 900;
+    letter-spacing: 0.2em; border-radius: 0.7rem;
+  }
+
+  /* Panel */
+  .p-panel {
+    width: 100%; border-radius: 1rem;
+    padding: 0.85rem 0.95rem;
+    transition: all 0.3s;
+  }
+  .p-panel-title {
+    font-size: 0.62rem; font-weight: 800; text-transform: uppercase;
+    letter-spacing: 0.12em; margin-bottom: 0.5rem;
+  }
+
+  /* Players */
+  .p-player-list { display: flex; flex-wrap: wrap; gap: 0.4rem; }
+  .p-player-chip {
+    display: flex; align-items: center; gap: 0.35rem;
+    padding: 0.35rem 0.6rem 0.35rem 0.4rem;
+    font-size: 0.8rem; font-weight: 700;
+    transition: all 0.3s;
+  }
+  .p-player-chip .avatar { line-height: 1; }
+  .p-player-chip .ready { font-size: 0.75rem; margin-left: 0.1rem; }
+  .p-player-chip.p-me { }
+  .p-player-chip.p-admin { }
+
+  /* Game grid */
+  .p-game-grid { display: grid; gap: 0.55rem; }
+  .p-game-tile {
+    display: flex; flex-direction: column;
+    align-items: center; justify-content: center; gap: 0.25rem;
+    min-height: 80px; cursor: default;
+    text-align: center; transition: all 0.25s cubic-bezier(0.34,1.56,0.64,1);
+  }
+  .p-game-tile:hover { transform: translateY(-2px); }
+  .p-tile-emoji { font-size: 1.8rem; line-height: 1; }
+  .p-tile-label { font-size: 0.82rem; font-weight: 700; }
+  .p-tile-votes {
+    display: flex; align-items: center; gap: 0.15rem;
+    padding: 0.1rem 0.4rem; font-size: 0.65rem; font-weight: 800;
+    border-radius: 999px;
+  }
+  .p-game-tile.p-selected { }
+
+  /* Vote status */
+  .p-vote-status {
+    font-size: 0.75rem; text-align: center; padding: 0.15rem 0;
+    transition: all 0.3s;
+  }
+
+  /* QR strip */
+  .p-qr-strip {
+    width: 100%; display: flex; align-items: center; gap: 0.6rem;
+    border-radius: 1rem; padding: 0.5rem 0.75rem;
+    transition: all 0.3s;
+  }
+  .p-qr-box {
+    width: 50px; height: 50px; border-radius: 0.4rem;
+    display: flex; align-items: center; justify-content: center;
+    font-size: 0.55rem; font-weight: 800; flex-shrink: 0;
+  }
+  .p-qr-url { flex: 1; font-size: 0.65rem; font-weight: 700; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .p-qr-copy {
+    flex-shrink: 0; padding: 0.2rem 0.5rem; font-size: 0.65rem; font-weight: 700;
+    border-radius: 0.35rem; cursor: default; transition: all 0.2s;
+  }
+
+  /* Bottom actions */
+  .p-actions {
+    position: absolute; bottom: 0; left: 0; right: 0;
+    padding: 0.65rem 0.85rem 0.85rem;
+    display: flex; flex-direction: column; align-items: center; gap: 0.5rem;
+    z-index: 5; transition: all 0.3s;
+  }
+  .p-ready-btn {
+    width: 100%; padding: 0.7rem; font-size: 1rem; font-weight: 700;
+    border-radius: 0.7rem; cursor: default; text-align: center;
+    transition: all 0.3s;
+  }
+  .p-start-section {
+    width: 100%; display: flex; flex-direction: column; gap: 0.4rem;
+  }
+  .p-settings-row {
+    display: flex; gap: 0.3rem; flex-wrap: wrap; align-items: center;
+  }
+  .p-settings-label { font-size: 0.68rem; white-space: nowrap; }
+  .p-setting-btn {
+    padding: 0.25rem 0.55rem; font-size: 0.72rem; font-weight: 700;
+    border-radius: 0.4rem; cursor: default; transition: all 0.15s;
+  }
+  .p-start-btn {
+    width: 100%; padding: 0.75rem; font-size: 1.05rem; font-weight: 800;
+    border: none; border-radius: 0.7rem; cursor: default; text-align: center;
+    transition: all 0.3s;
+  }
+
+  /* ── Layouts ── */
+  .p-game-grid.layout-grid { grid-template-columns: 1fr 1fr; }
+  .p-game-grid.layout-list { grid-template-columns: 1fr; }
+  .p-game-grid.layout-list .p-game-tile {
+    flex-direction: row; min-height: 56px; justify-content: flex-start;
+    padding: 0.6rem 0.85rem; gap: 0.6rem; text-align: left;
+  }
+  .p-game-grid.layout-list .p-tile-emoji { font-size: 1.5rem; }
+  .p-game-grid.layout-cards { grid-template-columns: 1fr; gap: 0.75rem; }
+  .p-game-grid.layout-cards .p-game-tile {
+    min-height: 100px; padding: 1.2rem;
+  }
+  .p-game-grid.layout-cards .p-tile-emoji { font-size: 2.2rem; }
+
+  /* Player layout variants */
+  .p-player-list.pl-chips .p-player-chip { border-radius: 999px; }
+  .p-player-list.pl-cards .p-player-chip {
+    flex-direction: column; padding: 0.6rem 0.5rem; min-width: 60px;
+    text-align: center; border-radius: 0.7rem;
+  }
+  .p-player-list.pl-cards .p-player-chip .avatar { font-size: 1.4rem; }
+  .p-player-list.pl-cards .p-player-chip .name { font-size: 0.7rem; }
+  .p-player-list.pl-list { flex-direction: column; gap: 0.25rem; }
+  .p-player-list.pl-list .p-player-chip {
+    width: 100%; border-radius: 0.5rem; padding: 0.5rem 0.7rem;
+  }
+</style>
+</head>
+<body>
+
+<div class="topbar">
+  <div>
+    <span class="topbar-title">Game Night Lobby Playground</span>
+    <span class="topbar-sub"> &mdash; tweak everything, copy the prompt</span>
+  </div>
+</div>
+
+<!-- ── Controls ── -->
+<div class="controls" id="controls">
+  <div class="section-label">Presets</div>
+  <div class="preset-row">
+    <button class="preset-btn" onclick="applyPreset('default')">Current</button>
+    <button class="preset-btn" onclick="applyPreset('arcade')">Arcade</button>
+    <button class="preset-btn" onclick="applyPreset('minimal')">Minimal</button>
+    <button class="preset-btn" onclick="applyPreset('cozy')">Cozy</button>
+    <button class="preset-btn" onclick="applyPreset('cyber')">Cyberpunk</button>
+  </div>
+
+  <div class="section-label">Mood &amp; Color</div>
+
+  <div class="control-group">
+    <div class="control-label">Background <span class="control-value" id="val-bg"></span></div>
+    <div class="chip-row">
+      <button class="chip-btn" data-ctrl="bgStyle" data-val="mesh">Mesh gradient</button>
+      <button class="chip-btn" data-ctrl="bgStyle" data-val="solid">Solid dark</button>
+      <button class="chip-btn" data-ctrl="bgStyle" data-val="stars">Starfield</button>
+      <button class="chip-btn" data-ctrl="bgStyle" data-val="grid">Grid lines</button>
+    </div>
+  </div>
+
+  <div class="control-group">
+    <div class="control-label">Accent hue <span class="control-value" id="val-hue"></span></div>
+    <input type="range" min="0" max="360" id="ctrl-hue">
+  </div>
+
+  <div class="control-group">
+    <div class="control-label">Accent saturation <span class="control-value" id="val-sat"></span></div>
+    <input type="range" min="20" max="100" id="ctrl-sat">
+  </div>
+
+  <div class="control-group">
+    <div class="control-label">Glow intensity <span class="control-value" id="val-glow"></span></div>
+    <input type="range" min="0" max="100" id="ctrl-glow">
+  </div>
+
+  <div class="control-group">
+    <div class="control-label">Card opacity <span class="control-value" id="val-cardop"></span></div>
+    <input type="range" min="0" max="100" id="ctrl-cardop">
+  </div>
+
+  <div class="section-label">Layout</div>
+
+  <div class="control-group">
+    <div class="control-label">Game selector</div>
+    <div class="chip-row">
+      <button class="chip-btn" data-ctrl="gameLayout" data-val="grid">Grid</button>
+      <button class="chip-btn" data-ctrl="gameLayout" data-val="list">List</button>
+      <button class="chip-btn" data-ctrl="gameLayout" data-val="cards">Big cards</button>
+    </div>
+  </div>
+
+  <div class="control-group">
+    <div class="control-label">Player display</div>
+    <div class="chip-row">
+      <button class="chip-btn" data-ctrl="playerLayout" data-val="chips">Chips</button>
+      <button class="chip-btn" data-ctrl="playerLayout" data-val="cards">Avatar cards</button>
+      <button class="chip-btn" data-ctrl="playerLayout" data-val="list">List rows</button>
+    </div>
+  </div>
+
+  <div class="section-label">Shape &amp; Feel</div>
+
+  <div class="control-group">
+    <div class="control-label">Border radius <span class="control-value" id="val-radius"></span></div>
+    <input type="range" min="0" max="28" id="ctrl-radius">
+  </div>
+
+  <div class="control-group">
+    <div class="control-label">Panel border</div>
+    <div class="chip-row">
+      <button class="chip-btn" data-ctrl="panelBorder" data-val="subtle">Subtle</button>
+      <button class="chip-btn" data-ctrl="panelBorder" data-val="glow">Glow</button>
+      <button class="chip-btn" data-ctrl="panelBorder" data-val="none">None</button>
+      <button class="chip-btn" data-ctrl="panelBorder" data-val="solid">Solid</button>
+    </div>
+  </div>
+
+  <div class="control-group">
+    <div class="control-label">Glass blur <span class="control-value" id="val-blur"></span></div>
+    <input type="range" min="0" max="30" id="ctrl-blur">
+  </div>
+
+  <div class="section-label">Typography</div>
+
+  <div class="control-group">
+    <div class="control-label">Title style</div>
+    <div class="chip-row">
+      <button class="chip-btn" data-ctrl="titleStyle" data-val="gradient">Gradient</button>
+      <button class="chip-btn" data-ctrl="titleStyle" data-val="solid">Solid white</button>
+      <button class="chip-btn" data-ctrl="titleStyle" data-val="neon">Neon glow</button>
+      <button class="chip-btn" data-ctrl="titleStyle" data-val="outline">Outline</button>
+    </div>
+  </div>
+
+  <div class="control-group">
+    <div class="control-label">Title size <span class="control-value" id="val-titlesize"></span></div>
+    <input type="range" min="10" max="18" id="ctrl-titlesize">
+  </div>
+
+  <div class="control-group">
+    <div class="control-label">Font weight <span class="control-value" id="val-weight"></span></div>
+    <input type="range" min="400" max="900" step="100" id="ctrl-weight">
+  </div>
+
+  <div class="section-label">Buttons</div>
+
+  <div class="control-group">
+    <div class="control-label">Start button style</div>
+    <div class="chip-row">
+      <button class="chip-btn" data-ctrl="btnStyle" data-val="gradient">Gradient</button>
+      <button class="chip-btn" data-ctrl="btnStyle" data-val="solid">Solid</button>
+      <button class="chip-btn" data-ctrl="btnStyle" data-val="outline">Outline</button>
+      <button class="chip-btn" data-ctrl="btnStyle" data-val="neon">Neon pulse</button>
+    </div>
+  </div>
+
+  <div class="control-group">
+    <div class="control-label">Ready button style</div>
+    <div class="chip-row">
+      <button class="chip-btn" data-ctrl="readyStyle" data-val="outline">Outline</button>
+      <button class="chip-btn" data-ctrl="readyStyle" data-val="filled">Filled</button>
+      <button class="chip-btn" data-ctrl="readyStyle" data-val="pill">Pill</button>
+    </div>
+  </div>
+
+  <div class="section-label">Animation</div>
+
+  <div class="control-group">
+    <div class="control-label">Animation intensity <span class="control-value" id="val-anim"></span></div>
+    <input type="range" min="0" max="100" id="ctrl-anim">
+  </div>
+
+  <div class="control-group">
+    <div class="control-label">Entrance</div>
+    <div class="chip-row">
+      <button class="chip-btn" data-ctrl="entrance" data-val="fade">Fade</button>
+      <button class="chip-btn" data-ctrl="entrance" data-val="slide">Slide up</button>
+      <button class="chip-btn" data-ctrl="entrance" data-val="bounce">Bounce</button>
+      <button class="chip-btn" data-ctrl="entrance" data-val="none">None</button>
+    </div>
+  </div>
+
+  <div class="section-label">QR Strip</div>
+  <div class="control-group">
+    <div class="control-label">QR visibility</div>
+    <div class="chip-row">
+      <button class="chip-btn" data-ctrl="qrVisible" data-val="show">Show</button>
+      <button class="chip-btn" data-ctrl="qrVisible" data-val="hide">Hide</button>
+    </div>
+  </div>
+</div>
+
+<!-- ── Preview ── -->
+<div class="preview-wrap" id="preview-wrap">
+  <button class="bezel-toggle" id="bezel-toggle">Phone frame</button>
+  <div class="preview-frame" id="preview"></div>
+</div>
+
+<!-- ── Prompt ── -->
+<div class="prompt-bar">
+  <div class="prompt-text" id="prompt-text">Adjust controls to generate a prompt...</div>
+  <button class="copy-btn" id="copy-btn">Copy Prompt</button>
+</div>
+
+<script>
+// ── Defaults ──
+const DEFAULTS = {
+  bgStyle: 'mesh',
+  hue: 28,        // orange
+  sat: 100,
+  glow: 40,
+  cardop: 85,
+  gameLayout: 'grid',
+  playerLayout: 'chips',
+  radius: 16,
+  panelBorder: 'subtle',
+  blur: 16,
+  titleStyle: 'gradient',
+  titlesize: 13,
+  weight: 900,
+  btnStyle: 'gradient',
+  readyStyle: 'outline',
+  anim: 50,
+  entrance: 'fade',
+  qrVisible: 'show',
+};
+
+const state = { ...DEFAULTS };
+
+const MOCK_PLAYERS = [
+  { name: 'Skogix', avatar: '🦊', ready: true, me: true, admin: true },
+  { name: 'Alice', avatar: '🐼', ready: true, me: false, admin: false },
+  { name: 'Bob', avatar: '🦁', ready: false, me: false, admin: false },
+  { name: 'Charlie', avatar: '🐸', ready: true, me: false, admin: false },
+];
+
+const MOCK_GAMES = [
+  { type: 'quiz', emoji: '🧠', label: 'Quiz', votes: 3, selected: true },
+  { type: 'shithead', emoji: '🃏', label: 'Shithead', votes: 1, selected: false },
+];
+
+// ── Presets ──
+const PRESETS = {
+  default: { ...DEFAULTS },
+  arcade: {
+    bgStyle: 'grid', hue: 270, sat: 80, glow: 80, cardop: 70,
+    gameLayout: 'cards', playerLayout: 'cards', radius: 20,
+    panelBorder: 'glow', blur: 20, titleStyle: 'neon', titlesize: 16,
+    weight: 900, btnStyle: 'neon', readyStyle: 'pill', anim: 90, entrance: 'bounce',
+    qrVisible: 'show',
+  },
+  minimal: {
+    bgStyle: 'solid', hue: 210, sat: 30, glow: 0, cardop: 50,
+    gameLayout: 'list', playerLayout: 'list', radius: 8,
+    panelBorder: 'none', blur: 0, titleStyle: 'solid', titlesize: 12,
+    weight: 700, btnStyle: 'outline', readyStyle: 'outline', anim: 10, entrance: 'fade',
+    qrVisible: 'hide',
+  },
+  cozy: {
+    bgStyle: 'mesh', hue: 30, sat: 70, glow: 25, cardop: 90,
+    gameLayout: 'cards', playerLayout: 'chips', radius: 24,
+    panelBorder: 'subtle', blur: 24, titleStyle: 'gradient', titlesize: 15,
+    weight: 800, btnStyle: 'solid', readyStyle: 'filled', anim: 40, entrance: 'slide',
+    qrVisible: 'show',
+  },
+  cyber: {
+    bgStyle: 'grid', hue: 180, sat: 100, glow: 95, cardop: 60,
+    gameLayout: 'grid', playerLayout: 'chips', radius: 4,
+    panelBorder: 'glow', blur: 8, titleStyle: 'neon', titlesize: 14,
+    weight: 900, btnStyle: 'neon', readyStyle: 'outline', anim: 75, entrance: 'slide',
+    qrVisible: 'show',
+  },
+};
+
+// ── Helpers ──
+function hsl(h, s, l) { return `hsl(${h}, ${s}%, ${l}%)`; }
+function hsla(h, s, l, a) { return `hsla(${h}, ${s}%, ${l}%, ${a})`; }
+
+function accent(l = 55) { return hsl(state.hue, state.sat, l); }
+function accentA(a, l = 55) { return hsla(state.hue, state.sat, l, a); }
+function accent2(l = 50) { return hsl((state.hue + 140) % 360, state.sat * 0.8, l); }
+function accent2A(a, l = 50) { return hsla((state.hue + 140) % 360, state.sat * 0.8, l, a); }
+
+// ── Render ──
+function renderPreview() {
+  const p = document.getElementById('preview');
+  const bg = '#0f0e17';
+  const bgAlt = '#1a1932';
+  const r = state.radius;
+  const glowStr = state.glow / 100;
+
+  // BG style
+  let bgCSS = bg;
+  let bgBefore = '';
+  if (state.bgStyle === 'mesh') {
+    bgBefore = `<div style="position:absolute;inset:-50%;pointer-events:none;z-index:0;
+      background:
+        radial-gradient(ellipse 60% 50% at 20% 30%, ${accentA(0.12)} 0%, transparent 60%),
+        radial-gradient(ellipse 50% 60% at 80% 70%, ${accent2A(0.10)} 0%, transparent 60%),
+        radial-gradient(ellipse 40% 40% at 50% 50%, ${accentA(0.06, 40)} 0%, transparent 50%);
+      animation: pMeshDrift 16s ease-in-out infinite alternate;"></div>`;
+  } else if (state.bgStyle === 'stars') {
+    let stars = '';
+    for (let i = 0; i < 80; i++) {
+      const x = Math.random() * 100, y = Math.random() * 100;
+      const s = 1 + Math.random() * 2;
+      const o = 0.2 + Math.random() * 0.6;
+      stars += `<circle cx="${x}%" cy="${y}%" r="${s}" fill="white" opacity="${o}"/>`;
+    }
+    bgBefore = `<svg style="position:absolute;inset:0;width:100%;height:100%;pointer-events:none;z-index:0">${stars}</svg>`;
+  } else if (state.bgStyle === 'grid') {
+    bgBefore = `<div style="position:absolute;inset:0;pointer-events:none;z-index:0;
+      background-image:
+        linear-gradient(${accentA(0.06)} 1px, transparent 1px),
+        linear-gradient(90deg, ${accentA(0.06)} 1px, transparent 1px);
+      background-size: 30px 30px;"></div>`;
+  }
+
+  // Card style
+  const cardBg = `rgba(26, 25, 50, ${state.cardop / 100})`;
+  const blurVal = state.blur;
+  let borderStyle = '';
+  if (state.panelBorder === 'subtle') borderStyle = `border: 1px solid rgba(255,255,255,0.06);`;
+  else if (state.panelBorder === 'glow') borderStyle = `border: 1px solid ${accentA(0.3)}; box-shadow: 0 0 ${15 * glowStr}px ${accentA(0.15)};`;
+  else if (state.panelBorder === 'none') borderStyle = `border: 1px solid transparent;`;
+  else if (state.panelBorder === 'solid') borderStyle = `border: 2px solid rgba(255,255,255,0.15);`;
+
+  const panelStyle = `background:${cardBg};${blurVal > 0 ? `backdrop-filter:blur(${blurVal}px);-webkit-backdrop-filter:blur(${blurVal}px);` : ''}${borderStyle}border-radius:${r}px;`;
+
+  // Title style
+  let titleCSS = '';
+  if (state.titleStyle === 'gradient') {
+    titleCSS = `background:linear-gradient(135deg,${accent()},${accent2()});-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text;`;
+  } else if (state.titleStyle === 'solid') {
+    titleCSS = `color:#fffffe;`;
+  } else if (state.titleStyle === 'neon') {
+    titleCSS = `color:${accent(70)};text-shadow:0 0 ${10 * glowStr}px ${accentA(0.6)},0 0 ${30 * glowStr}px ${accentA(0.3)};`;
+  } else if (state.titleStyle === 'outline') {
+    titleCSS = `-webkit-text-fill-color:transparent;-webkit-text-stroke:1.5px ${accent()};`;
+  }
+
+  // Entrance animation
+  let animStyle = '';
+  const dur = 0.2 + (state.anim / 100) * 0.6;
+  if (state.entrance === 'fade') animStyle = `animation:pfadeIn ${dur}s ease-out both;`;
+  else if (state.entrance === 'slide') animStyle = `animation:pslideUp ${dur}s ease-out both;`;
+  else if (state.entrance === 'bounce') animStyle = `animation:pbounceIn ${dur}s cubic-bezier(0.34,1.56,0.64,1) both;`;
+
+  // Players
+  const plClass = `pl-${state.playerLayout}`;
+  let chipRadius = state.playerLayout === 'chips' ? '999px' : state.playerLayout === 'cards' ? `${r * 0.6}px` : `${r * 0.4}px`;
+  const playersHTML = MOCK_PLAYERS.map((pl, i) => {
+    let chipBg = 'rgba(255,255,255,0.04)';
+    let chipBorder = 'rgba(255,255,255,0.06)';
+    if (pl.me) { chipBg = accentA(0.08); chipBorder = accentA(0.4); }
+    if (pl.admin) { chipBg = 'rgba(255,215,0,0.08)'; chipBorder = 'rgba(255,215,0,0.4)'; }
+    const delay = state.entrance !== 'none' ? `animation-delay:${i * 0.06}s;` : '';
+    return `<div class="p-player-chip ${pl.me ? 'p-me' : ''} ${pl.admin ? 'p-admin' : ''}"
+      style="background:${chipBg};border:1.5px solid ${chipBorder};border-radius:${chipRadius};${animStyle}${delay}">
+      <span class="avatar">${pl.avatar}</span>
+      <span class="name">${pl.name}</span>
+      ${pl.admin ? '<span style="font-size:0.75rem">👑</span>' : ''}
+      <span class="ready">${pl.ready ? '✅' : '⏳'}</span>
+    </div>`;
+  }).join('');
+
+  // Game tiles
+  const layoutClass = `layout-${state.gameLayout}`;
+  const gamesHTML = MOCK_GAMES.map((g, i) => {
+    let tileBg = 'rgba(255,255,255,0.03)';
+    let tileBorder = 'rgba(255,255,255,0.06)';
+    let tileShadow = 'none';
+    if (g.selected) {
+      tileBg = accentA(0.12);
+      tileBorder = accentA(0.5);
+      tileShadow = `0 0 ${20 * glowStr}px ${accentA(0.15)}`;
+    }
+    const delay = state.entrance !== 'none' ? `animation-delay:${i * 0.08 + 0.15}s;` : '';
+    return `<div class="p-game-tile ${g.selected ? 'p-selected' : ''}"
+      style="background:${tileBg};border:2px solid ${tileBorder};border-radius:${r}px;box-shadow:${tileShadow};${animStyle}${delay}">
+      <span class="p-tile-emoji">${g.emoji}</span>
+      <span class="p-tile-label">${g.label}</span>
+      ${g.votes > 0 ? `<span class="p-tile-votes" style="background:${accentA(0.2)};border:1px solid ${accentA(0.35)};color:${accent()}">\u25B2 ${g.votes}</span>` : ''}
+    </div>`;
+  }).join('');
+
+  // Ready btn style
+  let readyCSS = '';
+  if (state.readyStyle === 'outline') readyCSS = `background:rgba(255,255,255,0.04);color:#a7a9be;border:2px solid rgba(255,255,255,0.08);`;
+  else if (state.readyStyle === 'filled') readyCSS = `background:rgba(44,182,125,0.12);color:#2cb67d;border:2px solid #2cb67d;`;
+  else if (state.readyStyle === 'pill') readyCSS = `background:rgba(255,255,255,0.04);color:#a7a9be;border:2px solid rgba(255,255,255,0.08);border-radius:999px;`;
+
+  // Start btn style
+  let startCSS = '';
+  if (state.btnStyle === 'gradient') startCSS = `background:linear-gradient(135deg,${accent()},${accent2()});color:#fff;border:none;box-shadow:0 4px 15px ${accentA(0.3)};`;
+  else if (state.btnStyle === 'solid') startCSS = `background:${accent()};color:#fff;border:none;box-shadow:0 4px 15px ${accentA(0.3)};`;
+  else if (state.btnStyle === 'outline') startCSS = `background:transparent;color:${accent()};border:2px solid ${accent()};`;
+  else if (state.btnStyle === 'neon') startCSS = `background:transparent;color:${accent(70)};border:2px solid ${accent()};box-shadow:0 0 ${15 * glowStr}px ${accentA(0.4)},inset 0 0 ${15 * glowStr}px ${accentA(0.1)};text-shadow:0 0 ${8 * glowStr}px ${accentA(0.5)};${state.anim > 30 ? `animation:pglow ${2 - state.anim/100}s ease-in-out infinite;` : ''}`;
+
+  // Settings buttons
+  const settActiveCSS = `background:${accentA(0.15)};border-color:${accent()};color:${accent()};`;
+  const settInactiveCSS = `background:rgba(255,255,255,0.04);border:1.5px solid rgba(255,255,255,0.08);color:#a7a9be;`;
+
+  // QR strip
+  const qrHTML = state.qrVisible === 'show' ? `
+    <div class="p-qr-strip" style="${panelStyle}background:${accent2A(0.06)};border-color:${accent2A(0.15)};">
+      <div class="p-qr-box" style="background:#fff;color:#000;">QR</div>
+      <div class="p-qr-url" style="${state.titleStyle === 'gradient' ? `background:linear-gradient(135deg,${accent2()},${accent()});-webkit-background-clip:text;-webkit-text-fill-color:transparent;` : `color:${accent2()};`}">192.168.1.42:3000/group/XKCD</div>
+      <div class="p-qr-copy" style="background:${accent2A(0.15)};color:${accent2()};border:1px solid ${accent2A(0.3)};border-radius:${r * 0.3}px;">Copy</div>
+    </div>` : '';
+
+  // Vote status
+  const voteCSS = `color:#2cb67d;font-weight:700;`;
+
+  p.innerHTML = `
+    <style>
+      @keyframes pfadeIn { from { opacity: 0; transform: translateY(6px); } to { opacity: 1; transform: translateY(0); } }
+      @keyframes pslideUp { from { transform: translateY(16px); opacity: 0; } to { transform: translateY(0); opacity: 1; } }
+      @keyframes pbounceIn { 0% { transform: scale(0.3); opacity: 0; } 50% { transform: scale(1.08); } 70% { transform: scale(0.95); } 100% { transform: scale(1); opacity: 1; } }
+      @keyframes pglow { 0%, 100% { box-shadow: 0 0 15px ${accentA(0.3)}; } 50% { box-shadow: 0 0 30px ${accentA(0.5)}, 0 0 50px ${accentA(0.2)}; } }
+    </style>
+    <div class="p-body p-bg-mesh" style="background:${bg};font-family:'Inter','Segoe UI',system-ui,sans-serif;">
+      ${bgBefore}
+
+      <div class="p-header" style="z-index:1;${animStyle}">
+        <div class="p-header-title" style="font-size:${state.titlesize * 0.8}px;font-weight:${state.weight};${titleCSS}">Game Night</div>
+        <div class="p-header-right">
+          <div class="p-rules-link" style="color:#a7a9be;background:rgba(255,255,255,0.06);border:1px solid rgba(255,255,255,0.08);font-size:0.65rem;">Rules</div>
+          <div class="p-room-chip" style="background:linear-gradient(135deg,${accentA(0.15)},${accent2A(0.15)});border:1px solid ${accentA(0.3)};color:${accent()};font-size:0.95rem;border-radius:${r * 0.5}px;">XKCD</div>
+        </div>
+      </div>
+
+      <div class="p-panel" style="${panelStyle}${animStyle}animation-delay:0.05s;">
+        <div class="p-panel-title" style="color:#555770;">Players (${MOCK_PLAYERS.length})</div>
+        <div class="p-player-list ${plClass}">${playersHTML}</div>
+      </div>
+
+      <div class="p-panel" style="${panelStyle}${animStyle}animation-delay:0.1s;">
+        <div class="p-panel-title" style="color:#555770;">Pick a Game</div>
+        <div class="p-game-grid ${layoutClass}">${gamesHTML}</div>
+      </div>
+
+      <div class="p-vote-status" style="${voteCSS}${animStyle}animation-delay:0.15s;">3 / 4 ready</div>
+
+      ${qrHTML ? `<div style="${animStyle}animation-delay:0.18s;width:100%;">${qrHTML}</div>` : ''}
+
+      <div class="p-actions" style="background:rgba(15,14,23,0.97);backdrop-filter:blur(12px);border-top:1px solid rgba(255,255,255,0.04);">
+        <div class="p-ready-btn" style="${readyCSS}border-radius:${state.readyStyle === 'pill' ? '999px' : r * 0.55 + 'px'};">I'm Ready</div>
+        <div class="p-start-section">
+          <div class="p-settings-row">
+            <span class="p-settings-label" style="color:#555770;">Difficulty:</span>
+            <span class="p-setting-btn" style="${settActiveCSS}border-radius:${r * 0.3}px;">Easy</span>
+            <span class="p-setting-btn" style="${settInactiveCSS}border-radius:${r * 0.3}px;">Medium</span>
+            <span class="p-setting-btn" style="${settInactiveCSS}border-radius:${r * 0.3}px;">Hard</span>
+          </div>
+          <div class="p-settings-row">
+            <span class="p-settings-label" style="color:#555770;">Questions:</span>
+            <span class="p-setting-btn" style="${settActiveCSS}border-radius:${r * 0.3}px;">10</span>
+            <span class="p-setting-btn" style="${settInactiveCSS}border-radius:${r * 0.3}px;">15</span>
+            <span class="p-setting-btn" style="${settInactiveCSS}border-radius:${r * 0.3}px;">20</span>
+          </div>
+          <div class="p-start-btn" style="${startCSS}border-radius:${r * 0.55}px;font-weight:${state.weight};${animStyle}animation-delay:0.2s;">Start Game</div>
+        </div>
+      </div>
+    </div>
+  `;
+}
+
+function updatePrompt() {
+  const parts = [];
+  const diff = (key) => state[key] !== DEFAULTS[key];
+
+  // Background
+  if (diff('bgStyle')) {
+    const labels = { mesh: 'animated mesh gradient', solid: 'solid dark', stars: 'animated starfield particles', grid: 'subtle grid lines' };
+    parts.push(`Use a **${labels[state.bgStyle]}** background`);
+  }
+
+  // Accent color
+  if (diff('hue') || diff('sat')) {
+    const hueNames = [
+      [0, 'red'], [30, 'orange'], [50, 'amber'], [60, 'yellow'], [120, 'green'],
+      [170, 'teal'], [195, 'cyan'], [220, 'blue'], [260, 'indigo'], [280, 'purple'],
+      [310, 'pink'], [340, 'rose'], [360, 'red'],
+    ];
+    let hueName = 'custom';
+    for (let i = 0; i < hueNames.length - 1; i++) {
+      if (state.hue >= hueNames[i][0] && state.hue < hueNames[i + 1][0]) { hueName = hueNames[i][1]; break; }
+    }
+    const satDesc = state.sat < 40 ? 'muted' : state.sat < 70 ? 'moderate' : 'vivid';
+    parts.push(`Shift the accent color to a **${satDesc} ${hueName}** (hue ${state.hue}, saturation ${state.sat}%)`);
+  }
+
+  // Glow
+  if (diff('glow')) {
+    if (state.glow === 0) parts.push('Remove all glow effects');
+    else if (state.glow < 30) parts.push('Use **subtle, restrained** glow effects');
+    else if (state.glow > 70) parts.push('Use **pronounced, dramatic** glow effects on selected items and buttons');
+  }
+
+  // Card opacity
+  if (diff('cardop')) {
+    if (state.cardop < 40) parts.push('Make panel backgrounds very **transparent/see-through**');
+    else if (state.cardop > 90) parts.push('Make panel backgrounds **nearly opaque**');
+    else if (diff('cardop')) parts.push(`Set card background opacity to **${state.cardop}%**`);
+  }
+
+  // Layout
+  if (diff('gameLayout')) {
+    const labels = { grid: '2-column grid', list: 'single-column list rows', cards: 'large stacked cards' };
+    parts.push(`Display game selector as **${labels[state.gameLayout]}**`);
+  }
+  if (diff('playerLayout')) {
+    const labels = { chips: 'horizontal pill chips', cards: 'small avatar cards', list: 'full-width list rows' };
+    parts.push(`Show players as **${labels[state.playerLayout]}**`);
+  }
+
+  // Shape
+  if (diff('radius')) {
+    if (state.radius <= 4) parts.push('Use **sharp, squared-off** corners (radius ~' + state.radius + 'px)');
+    else if (state.radius >= 22) parts.push('Use **very rounded, bubbly** corners (radius ~' + state.radius + 'px)');
+    else parts.push(`Set border-radius to **${state.radius}px**`);
+  }
+
+  if (diff('panelBorder')) {
+    const labels = { subtle: 'subtle hairline', glow: 'accent-colored glow', none: 'no visible', solid: 'solid white' };
+    parts.push(`Use **${labels[state.panelBorder]}** borders on panels`);
+  }
+
+  if (diff('blur')) {
+    if (state.blur === 0) parts.push('Remove backdrop blur (no glassmorphism)');
+    else if (state.blur > 20) parts.push(`Use **heavy glassmorphism** (${state.blur}px backdrop blur)`);
+    else if (diff('blur')) parts.push(`Set backdrop blur to **${state.blur}px**`);
+  }
+
+  // Typography
+  if (diff('titleStyle')) {
+    const labels = { gradient: 'gradient-filled', solid: 'solid white', neon: 'neon glow', outline: 'outlined/stroked' };
+    parts.push(`Make the title text **${labels[state.titleStyle]}**`);
+  }
+  if (diff('titlesize')) {
+    parts.push(`Title font-size roughly **${state.titlesize}px**`);
+  }
+  if (diff('weight')) {
+    const wLabels = { 400: 'regular', 500: 'medium', 600: 'semi-bold', 700: 'bold', 800: 'extra-bold', 900: 'black/heavy' };
+    parts.push(`Use **${wLabels[state.weight] || state.weight}** font weight for headings and buttons`);
+  }
+
+  // Buttons
+  if (diff('btnStyle')) {
+    const labels = { gradient: 'a gradient fill', solid: 'a solid accent fill', outline: 'an outlined/border-only', neon: 'a neon-pulsing glow' };
+    parts.push(`Give the Start button **${labels[state.btnStyle]}** style`);
+  }
+  if (diff('readyStyle')) {
+    const labels = { outline: 'a subtle outlined', filled: 'a filled/highlighted', pill: 'a rounded pill' };
+    parts.push(`Make the Ready button **${labels[state.readyStyle]}** style`);
+  }
+
+  // Animation
+  if (diff('anim')) {
+    if (state.anim < 15) parts.push('Use **minimal/no** animations — feels snappy and instant');
+    else if (state.anim > 70) parts.push('Use **exaggerated, playful** animations with longer durations and spring easing');
+  }
+  if (diff('entrance')) {
+    const labels = { fade: 'fade-in', slide: 'slide-up', bounce: 'bounce-in', none: 'no entrance' };
+    parts.push(`Use **${labels[state.entrance]}** entrance animations for elements`);
+  }
+
+  if (diff('qrVisible') && state.qrVisible === 'hide') {
+    parts.push('**Hide the QR code strip** from the lobby view');
+  }
+
+  const prompt = document.getElementById('prompt-text');
+  if (parts.length === 0) {
+    prompt.textContent = 'This matches the current design. Change some controls to generate a redesign prompt.';
+  } else {
+    prompt.innerHTML = `Redesign the Game Night lobby setup page (<code>public/group/index.html</code>):\n\n` +
+      parts.map((p, i) => `${i + 1}. ${p}`).join('\n') +
+      `\n\nKeep the existing functionality (WebSocket connection, player list, game voting, ready/start flow, QR code). Only change the visual presentation and CSS.`;
+  }
+}
+
+function updateAll() {
+  renderPreview();
+  updatePrompt();
+  syncControls();
+}
+
+// ── Sync UI controls to state ──
+function syncControls() {
+  // Sliders
+  ['hue', 'sat', 'glow', 'cardop', 'radius', 'blur', 'titlesize', 'weight', 'anim'].forEach(k => {
+    const el = document.getElementById(`ctrl-${k}`);
+    if (el) el.value = state[k];
+  });
+  // Value displays
+  document.getElementById('val-hue').textContent = state.hue + '°';
+  document.getElementById('val-sat').textContent = state.sat + '%';
+  document.getElementById('val-glow').textContent = state.glow + '%';
+  document.getElementById('val-cardop').textContent = state.cardop + '%';
+  document.getElementById('val-radius').textContent = state.radius + 'px';
+  document.getElementById('val-blur').textContent = state.blur + 'px';
+  document.getElementById('val-titlesize').textContent = state.titlesize + 'px';
+  document.getElementById('val-weight').textContent = state.weight;
+  document.getElementById('val-anim').textContent = state.anim + '%';
+
+  // Chip buttons
+  document.querySelectorAll('.chip-btn[data-ctrl]').forEach(btn => {
+    btn.classList.toggle('active', state[btn.dataset.ctrl] === btn.dataset.val);
+  });
+}
+
+// ── Wire controls ──
+['hue', 'sat', 'glow', 'cardop', 'radius', 'blur', 'titlesize', 'weight', 'anim'].forEach(k => {
+  const el = document.getElementById(`ctrl-${k}`);
+  if (el) el.addEventListener('input', () => { state[k] = Number(el.value); updateAll(); });
+});
+
+document.querySelectorAll('.chip-btn[data-ctrl]').forEach(btn => {
+  btn.addEventListener('click', () => {
+    state[btn.dataset.ctrl] = btn.dataset.val;
+    updateAll();
+  });
+});
+
+// Bezel toggle
+document.getElementById('bezel-toggle').addEventListener('click', () => {
+  document.getElementById('preview-wrap').classList.toggle('phone-bezel');
+});
+
+// Copy button
+document.getElementById('copy-btn').addEventListener('click', async () => {
+  const text = document.getElementById('prompt-text').innerText;
+  try {
+    await navigator.clipboard.writeText(text);
+    const btn = document.getElementById('copy-btn');
+    btn.textContent = 'Copied!';
+    setTimeout(() => { btn.textContent = 'Copy Prompt'; }, 2000);
+  } catch (e) { /* ignore */ }
+});
+
+// Presets
+function applyPreset(name) {
+  Object.assign(state, PRESETS[name]);
+  updateAll();
+}
+
+// ── Init ──
+updateAll();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Adds a self-contained HTML playground (`quiz-setup-playground.html`) for visually exploring lobby redesign ideas
- Includes 5 presets (Current, Arcade, Minimal, Cozy, Cyberpunk), live phone-frame preview, and controls for color, layout, shape, typography, buttons, and animation
- Generates a copyable natural-language prompt describing only the changes from the current design, ready to paste back into Claude

## Test plan
- [ ] Open `quiz-setup-playground.html` in a browser
- [ ] Verify all 5 presets snap controls and preview correctly
- [ ] Verify sliders and chip toggles update the preview instantly
- [ ] Verify the prompt output only lists non-default changes
- [ ] Verify the Copy Prompt button works
- [ ] Toggle phone bezel frame on/off

🤖 Generated with [Claude Code](https://claude.com/claude-code)