### PR TITLE
refactor: make room.js game-agnostic via prepare hooks

### DIFF
--- a/src/engine/games/question-form.js
+++ b/src/engine/games/question-form.js
@@ -7,6 +7,21 @@
 // Questions are passed in via config.questions at game start.
 
 const questionForm = {
+  async prepare(config) {
+    // If questions are already provided (e.g. via WebSocket START_MINI_GAME), use them as-is
+    if (config.questions?.length) {
+      return { config };
+    }
+    // Otherwise load from file
+    const { loadQuestionFile } = await import('../../fetcher/question-file.js');
+    const file = config.file || 'todo-poll.json';
+    const loaded = await loadQuestionFile(file);
+    if (!loaded.ok) {
+      throw new Error(`Failed to load questions: ${loaded.error}`);
+    }
+    return { config: { ...config, questions: loaded.questions, _sourceFile: file } };
+  },
+
   setup({ players, config }) {
     const questions = config.questions || [];
 

--- a/src/engine/games/quiz.js
+++ b/src/engine/games/quiz.js
@@ -1,4 +1,5 @@
 // Small Hours - Quiz / Trivia Game
+import { fetchQuestions } from '../../fetcher/cached-fetcher.js';
 
 function shuffleArray(arr) {
   const shuffled = [...arr];
@@ -17,6 +18,38 @@ const PHASE_DURATIONS = {
 };
 
 const quiz = {
+  async prepare(config, { usedQuestionIds }) {
+    const amount = config.questionCount || 10;
+    const result = await fetchQuestions(config.categoryId, amount);
+    if (!result.ok) {
+      throw new Error(`Failed to fetch questions: ${result.error.message}`);
+    }
+
+    // Filter out questions already used in this room session
+    let unused = result.questions.filter(q => !usedQuestionIds.has(q.id));
+
+    // Supplement with a fresh fetch if not enough unused questions
+    if (unused.length < amount) {
+      const supplement = await fetchQuestions(config.categoryId, amount);
+      if (supplement.ok) {
+        const existingIds = new Set(unused.map(q => q.id));
+        for (const q of supplement.questions) {
+          if (!usedQuestionIds.has(q.id) && !existingIds.has(q.id)) {
+            unused.push(q);
+            existingIds.add(q.id);
+          }
+          if (unused.length >= amount) break;
+        }
+      }
+    }
+
+    const selected = unused.slice(0, amount);
+    return {
+      config: { ...config, questions: selected },
+      trackIds: selected.map(q => q.id),
+    };
+  },
+
   setup({ players, config }) {
     const questions = config.questions || [];
     const questionCount = config.questionCount || questions.length;

--- a/src/fetcher/cached-fetcher.js
+++ b/src/fetcher/cached-fetcher.js
@@ -132,6 +132,38 @@ export async function fetchCategories() {
 }
 
 /**
+ * Pre-warm the question cache at server startup.
+ * Fetches all categories, then questions for each category.
+ * Non-fatal: logs warnings on partial failures and continues.
+ * Already-cached categories/questions are skipped (disk hit = no API call).
+ */
+export async function prewarmCache() {
+  // 1. Fetch categories (hits disk if already cached)
+  const catResult = await fetchCategories();
+  if (!catResult.ok) {
+    console.warn('[prewarm] could not fetch categories:', catResult.error.message);
+    return;
+  }
+  console.log(`[prewarm] warming ${catResult.categories.length} categories...`);
+
+  // 2. For each category, fetch questions (hits disk if already cached)
+  let warmed = 0;
+  for (const cat of catResult.categories) {
+    const result = await fetchQuestions(cat.id, 50);
+    if (result.ok) {
+      warmed++;
+    } else {
+      console.warn(`[prewarm] failed category ${cat.id} (${cat.name}):`, result.error.message);
+    }
+  }
+  // Also warm the "any category" bucket
+  const anyResult = await fetchQuestions(null, 50);
+  if (anyResult.ok) warmed++;
+
+  console.log(`[prewarm] done — ${warmed}/${catResult.categories.length + 1} buckets ready`);
+}
+
+/**
  * Clear cached questions.
  *
  * @param {number|null} [categoryId] - If provided, removes only that category's file.

--- a/src/server.js
+++ b/src/server.js
@@ -6,6 +6,7 @@ import http from 'http';
 import manager from './session/manager.js';
 import { setupRoutes } from './transport/http.js';
 import { setupWebSocket } from './transport/ws-adapter.js';
+import { prewarmCache } from './fetcher/cached-fetcher.js';
 
 const PORT = parseInt(process.env.PORT, 10) || 3001;
 
@@ -29,6 +30,8 @@ server.listen(PORT, () => {
   console.log(`  Local:   http://localhost:${PORT}`);
   console.log(`  Health:  http://localhost:${PORT}/health`);
 });
+
+prewarmCache().catch(err => console.warn('[prewarm] startup cache warm failed:', err.message));
 
 // Graceful shutdown
 function shutdown(signal) {

--- a/src/session/room.js
+++ b/src/session/room.js
@@ -8,8 +8,7 @@ import quiz from '../engine/games/quiz.js';
 import questionForm from '../engine/games/question-form.js';
 import template from '../engine/games/template.js';
 import ginRummy from '../engine/games/gin-rummy.js';
-import { fetchQuestions } from '../fetcher/cached-fetcher.js';
-import { loadQuestionFile, saveAnswers } from '../fetcher/question-file.js';
+import { saveAnswers } from '../fetcher/question-file.js';
 
 const AVATAR_POOL = [
   '\u{1F98A}', '\u{1F438}', '\u{1F43C}', '\u{1F981}', '\u{1F42F}',
@@ -257,50 +256,15 @@ export class Room {
       throw new Error('No connected players to start a game');
     }
 
-    // Quiz-specific: fetch questions from cached-fetcher, deduplicate used questions
     let gameConfig = { ...config };
-    if (gameType === 'quiz') {
-      const amount = config.questionCount || 10;
-      const result = await fetchQuestions(config.categoryId, amount);
-      if (!result.ok) {
-        throw new Error(`Failed to fetch questions: ${result.error.message}`);
-      }
 
-      // Filter out questions already used in this room (per D-09)
-      let unused = result.questions.filter(q => !this.usedQuestionIds.has(q.id));
-
-      // If not enough unused questions, fetch fresh from API to supplement (per D-11)
-      if (unused.length < amount) {
-        const supplement = await fetchQuestions(config.categoryId, amount);
-        if (supplement.ok) {
-          const existingIds = new Set(unused.map(q => q.id));
-          for (const q of supplement.questions) {
-            if (!this.usedQuestionIds.has(q.id) && !existingIds.has(q.id)) {
-              unused.push(q);
-              existingIds.add(q.id);
-            }
-            if (unused.length >= amount) break;
-          }
-        }
+    // Let the game definition prepare its own config (fetch questions, load files, etc.)
+    if (definition.prepare) {
+      const result = await definition.prepare(gameConfig, { usedQuestionIds: this.usedQuestionIds });
+      gameConfig = result.config;
+      for (const id of result.trackIds ?? []) {
+        this.usedQuestionIds.add(id);
       }
-
-      // Track the questions we are about to use
-      const selected = unused.slice(0, amount);
-      for (const q of selected) {
-        this.usedQuestionIds.add(q.id);
-      }
-      gameConfig.questions = selected;
-    }
-
-    // Question-form: load questions from file if none provided
-    if (gameType === 'question-form' && !gameConfig.questions?.length) {
-      const file = gameConfig.file || 'todo-poll.json';
-      const loaded = await loadQuestionFile(file);
-      if (!loaded.ok) {
-        throw new Error(`Failed to load questions: ${loaded.error}`);
-      }
-      gameConfig.questions = loaded.questions;
-      gameConfig._sourceFile = file;
     }
 
     this.lastActivity = Date.now();


### PR DESCRIPTION
## Summary

- `room.js` no longer contains any game-specific logic — `startGame()` is now a generic dispatcher
- Quiz question fetching + session deduplication moved into `quiz.prepare()`
- Question-form file loading moved into `questionForm.prepare()`
- `prewarmCache()` added to `cached-fetcher.js` and called at server startup, so all game-time question fetches are instant disk reads rather than live API calls
- Game definition contract gains optional `async prepare(config, ctx) => { config, trackIds }` hook

## Why

`room.js` had two `if (gameType === ...)` branches that meant adding any new async game required editing the session layer. The `prepare` hook moves each game's pre-start data concern back into the game definition, keeping the session layer transport-agnostic.

## Test plan
- [ ] All existing tests pass
- [ ] `npm test` clean in the worktree
- [ ] Quiz game starts correctly with pre-cached questions
- [ ] Question-form game loads questions from file via prepare hook

Generated with [Claude Code](https://claude.ai/code)