### PR TITLE
test: add comprehensive coverage for 6 untested modules

### DIFF
--- a/tests/engine/engine.test.js
+++ b/tests/engine/engine.test.js
@@ -1,0 +1,216 @@
+// Unit tests for src/engine/engine.js
+// Covers createGame, processAction, getView, checkEnd — including error paths.
+
+import { describe, it, expect } from 'vitest';
+import {
+  createGame,
+  processAction,
+  getView,
+  checkEnd,
+} from '../../src/engine/engine.js';
+
+// -----------------------------------------------------------------------
+// Minimal stub game definition used across most tests
+// -----------------------------------------------------------------------
+const stubGame = {
+  setup({ players, config }) {
+    return {
+      players,
+      phase: 'playing',
+      counter: config.startAt ?? 0,
+      finished: false,
+      winner: null,
+    };
+  },
+  actions: {
+    increment(state, { playerId, amount = 1 }) {
+      if (state.finished) {
+        return { state, events: [{ type: 'error', message: 'Game is over' }] };
+      }
+      const newCounter = state.counter + amount;
+      const finished = newCounter >= 3;
+      return {
+        state: {
+          ...state,
+          counter: newCounter,
+          phase: finished ? 'finished' : 'playing',
+          finished,
+          winner: finished ? playerId : null,
+        },
+        events: [{ type: 'incremented', playerId, counter: newCounter }],
+      };
+    },
+    noop(state) {
+      return { state, events: [] };
+    },
+  },
+  view(state, playerId) {
+    return {
+      phase: state.phase,
+      counter: state.counter,
+      isPlayer: state.players.includes(playerId),
+    };
+  },
+  endIf(state) {
+    if (!state.finished) return null;
+    return { winner: state.winner, scores: {} };
+  },
+};
+
+// -----------------------------------------------------------------------
+// createGame
+// -----------------------------------------------------------------------
+describe('createGame', () => {
+  it('returns an object with id, state and definition', () => {
+    const game = createGame(stubGame, { players: ['p1'], config: {} });
+    expect(game).toHaveProperty('id');
+    expect(game).toHaveProperty('state');
+    expect(game).toHaveProperty('definition');
+  });
+
+  it('id is a non-empty string', () => {
+    const game = createGame(stubGame, { players: ['p1'], config: {} });
+    expect(typeof game.id).toBe('string');
+    expect(game.id.length).toBeGreaterThan(0);
+  });
+
+  it('each call produces a unique id', () => {
+    const g1 = createGame(stubGame, { players: ['p1'], config: {} });
+    const g2 = createGame(stubGame, { players: ['p1'], config: {} });
+    expect(g1.id).not.toBe(g2.id);
+  });
+
+  it('passes players and config to setup', () => {
+    const game = createGame(stubGame, { players: ['p1', 'p2'], config: { startAt: 5 } });
+    expect(game.state.players).toEqual(['p1', 'p2']);
+    expect(game.state.counter).toBe(5);
+  });
+
+  it('stores the game definition on the returned object', () => {
+    const game = createGame(stubGame, { players: ['p1'], config: {} });
+    expect(game.definition).toBe(stubGame);
+  });
+
+  it('state reflects setup initialisation', () => {
+    const game = createGame(stubGame, { players: ['p1'], config: {} });
+    expect(game.state.phase).toBe('playing');
+    expect(game.state.finished).toBe(false);
+  });
+});
+
+// -----------------------------------------------------------------------
+// processAction
+// -----------------------------------------------------------------------
+describe('processAction', () => {
+  it('dispatches a known action and returns updated game + events', () => {
+    const game = createGame(stubGame, { players: ['p1'], config: {} });
+    const { game: g2, events } = processAction(game, { type: 'increment', playerId: 'p1' });
+
+    expect(g2.state.counter).toBe(1);
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe('incremented');
+  });
+
+  it('returns error event for unknown action type', () => {
+    const game = createGame(stubGame, { players: ['p1'], config: {} });
+    const { game: same, events } = processAction(game, { type: 'unknownAction' });
+
+    // State should be unchanged
+    expect(same.state).toEqual(game.state);
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe('error');
+    expect(events[0].message).toMatch(/Unknown action/);
+  });
+
+  it('game id is preserved after action', () => {
+    const game = createGame(stubGame, { players: ['p1'], config: {} });
+    const { game: g2 } = processAction(game, { type: 'noop', playerId: 'p1' });
+    expect(g2.id).toBe(game.id);
+  });
+
+  it('definition is preserved after action', () => {
+    const game = createGame(stubGame, { players: ['p1'], config: {} });
+    const { game: g2 } = processAction(game, { type: 'noop', playerId: 'p1' });
+    expect(g2.definition).toBe(game.definition);
+  });
+
+  it('passes extra payload fields to the action handler', () => {
+    const game = createGame(stubGame, { players: ['p1'], config: {} });
+    const { game: g2 } = processAction(game, { type: 'increment', playerId: 'p1', amount: 2 });
+    expect(g2.state.counter).toBe(2);
+  });
+
+  it('does not mutate the original game', () => {
+    const game = createGame(stubGame, { players: ['p1'], config: {} });
+    const originalCounter = game.state.counter;
+    processAction(game, { type: 'increment', playerId: 'p1' });
+    expect(game.state.counter).toBe(originalCounter);
+  });
+
+  it('returns empty events array when action has none', () => {
+    const game = createGame(stubGame, { players: ['p1'], config: {} });
+    const { events } = processAction(game, { type: 'noop', playerId: 'p1' });
+    expect(events).toEqual([]);
+  });
+
+  it('action-level error still returns original game object', () => {
+    const game = createGame(stubGame, { players: ['p1'], config: {} });
+    // Force finished state by incrementing to 3
+    let g = game;
+    g = processAction(g, { type: 'increment', playerId: 'p1', amount: 3 }).game;
+    const { game: unchanged, events } = processAction(g, { type: 'increment', playerId: 'p1' });
+    expect(unchanged.state).toEqual(g.state);
+    expect(events[0].type).toBe('error');
+  });
+});
+
+// -----------------------------------------------------------------------
+// getView
+// -----------------------------------------------------------------------
+describe('getView', () => {
+  it('returns the view for a known player', () => {
+    const game = createGame(stubGame, { players: ['p1', 'p2'], config: {} });
+    const view = getView(game, 'p1');
+    expect(view.phase).toBe('playing');
+    expect(view.isPlayer).toBe(true);
+  });
+
+  it('returns view for a player not in the state (isPlayer false)', () => {
+    const game = createGame(stubGame, { players: ['p1'], config: {} });
+    const view = getView(game, 'spectator');
+    expect(view.isPlayer).toBe(false);
+  });
+
+  it('view reflects updated state after action', () => {
+    const game = createGame(stubGame, { players: ['p1'], config: {} });
+    const { game: g2 } = processAction(game, { type: 'increment', playerId: 'p1' });
+    const view = getView(g2, 'p1');
+    expect(view.counter).toBe(1);
+  });
+});
+
+// -----------------------------------------------------------------------
+// checkEnd
+// -----------------------------------------------------------------------
+describe('checkEnd', () => {
+  it('returns null while game is not over', () => {
+    const game = createGame(stubGame, { players: ['p1'], config: {} });
+    expect(checkEnd(game)).toBeNull();
+  });
+
+  it('returns result object when game has ended', () => {
+    const game = createGame(stubGame, { players: ['p1'], config: {} });
+    const { game: done } = processAction(game, { type: 'increment', playerId: 'p1', amount: 3 });
+    const result = checkEnd(done);
+    expect(result).not.toBeNull();
+    expect(result.winner).toBe('p1');
+    expect(result).toHaveProperty('scores');
+  });
+
+  it('does not mutate game state', () => {
+    const game = createGame(stubGame, { players: ['p1'], config: {} });
+    const stateBefore = JSON.stringify(game.state);
+    checkEnd(game);
+    expect(JSON.stringify(game.state)).toBe(stateBefore);
+  });
+});

--- a/tests/engine/quiz.test.js
+++ b/tests/engine/quiz.test.js
@@ -1,0 +1,485 @@
+// Unit tests for src/engine/games/quiz.js
+// Covers: answer submission (incl. powerups), all 4 timerExpired transitions with
+// actions/scoring, scoring mechanics, view filtering.
+// Note: quiz-timer.test.js covers bare phase transitions — this file adds
+// actions, scoring, powerups, and view behaviour.
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import quiz, { PHASE_DURATIONS } from '../../src/engine/games/quiz.js';
+import { createGame, processAction, getView, checkEnd } from '../../src/engine/engine.js';
+
+// -----------------------------------------------------------------------
+// Test fixtures
+// -----------------------------------------------------------------------
+const Q1 = {
+  id: 'q1',
+  question: 'What is 1+1?',
+  correct_answer: '2',
+  incorrect_answers: ['1', '3', '4'],
+  category: 'Math',
+  difficulty: 'easy',
+};
+const Q2 = {
+  id: 'q2',
+  question: 'Capital of France?',
+  correct_answer: 'Paris',
+  incorrect_answers: ['London', 'Berlin', 'Rome'],
+  category: 'Geography',
+  difficulty: 'easy',
+};
+
+function makeGame(players = ['p1', 'p2'], questions = [Q1, Q2]) {
+  return createGame(quiz, { players, config: { questions } });
+}
+
+/** Advance past the countdown phase so we're in 'question'. */
+function toQuestion(game) {
+  return processAction(game, { type: 'timerExpired', phase: 'countdown' }).game;
+}
+
+/** Advance past the question phase to 'reveal'. */
+function toReveal(game) {
+  const g1 = toQuestion(game);
+  return processAction(g1, { type: 'timerExpired', phase: 'question' }).game;
+}
+
+// -----------------------------------------------------------------------
+// Setup
+// -----------------------------------------------------------------------
+describe('Quiz - setup', () => {
+  it('starts in countdown phase', () => {
+    const game = makeGame();
+    expect(game.state.phase).toBe('countdown');
+  });
+
+  it('initialises scores and streaks to 0 for all players', () => {
+    const game = makeGame(['p1', 'p2', 'p3']);
+    expect(game.state.scores).toEqual({ p1: 0, p2: 0, p3: 0 });
+    expect(game.state.streaks).toEqual({ p1: 0, p2: 0, p3: 0 });
+  });
+
+  it('initialises all powerups as available', () => {
+    const game = makeGame(['p1']);
+    expect(game.state.powerups.p1).toEqual({ double: true, fifty: true, freeze: true });
+  });
+
+  it('sets currentQuestion to 0', () => {
+    const game = makeGame();
+    expect(game.state.currentQuestion).toBe(0);
+  });
+
+  it('stores questions from config', () => {
+    const game = makeGame();
+    expect(game.state.questions).toHaveLength(2);
+  });
+});
+
+// -----------------------------------------------------------------------
+// Answer submission
+// -----------------------------------------------------------------------
+describe('Quiz - answer action', () => {
+  it('records a plain answer in the question phase', () => {
+    const game = makeGame(['p1']);
+    const g1 = toQuestion(game);
+    const { game: g2, events } = processAction(g1, {
+      type: 'answer',
+      playerId: 'p1',
+      answerId: '2',
+    });
+    expect(g2.state.answers.p1).toBeDefined();
+    expect(g2.state.answers.p1.answerId).toBe('2');
+    expect(events[0].type).toBe('answer_submitted');
+    expect(events[0].playerId).toBe('p1');
+    expect(events[0].usedPowerup).toBeNull();
+  });
+
+  it('records the timestamp on answer', () => {
+    const game = makeGame(['p1']);
+    const g1 = toQuestion(game);
+    const before = Date.now();
+    const { game: g2 } = processAction(g1, {
+      type: 'answer',
+      playerId: 'p1',
+      answerId: '2',
+    });
+    const after = Date.now();
+    expect(g2.state.answers.p1.timestamp).toBeGreaterThanOrEqual(before);
+    expect(g2.state.answers.p1.timestamp).toBeLessThanOrEqual(after);
+  });
+
+  it('rejects answer when not in question phase', () => {
+    const game = makeGame(['p1']);
+    // Still in countdown
+    const { events } = processAction(game, {
+      type: 'answer',
+      playerId: 'p1',
+      answerId: '2',
+    });
+    expect(events[0].type).toBe('error');
+    expect(events[0].message).toMatch(/not in question/i);
+  });
+
+  it('rejects duplicate answer from same player', () => {
+    const game = makeGame(['p1']);
+    const g1 = toQuestion(game);
+    const { game: g2 } = processAction(g1, { type: 'answer', playerId: 'p1', answerId: '2' });
+    const { events } = processAction(g2, { type: 'answer', playerId: 'p1', answerId: '1' });
+    expect(events[0].type).toBe('error');
+    expect(events[0].message).toMatch(/already answered/i);
+  });
+
+  it('consuming double powerup marks it as used', () => {
+    const game = makeGame(['p1']);
+    const g1 = toQuestion(game);
+    const { game: g2, events } = processAction(g1, {
+      type: 'answer',
+      playerId: 'p1',
+      answerId: '2',
+      powerupType: 'double',
+    });
+    expect(g2.state.powerups.p1.double).toBe(false);
+    expect(events[0].usedPowerup).toBe('double');
+  });
+
+  it('consuming fifty powerup marks it as used', () => {
+    const game = makeGame(['p1']);
+    const g1 = toQuestion(game);
+    const { game: g2 } = processAction(g1, {
+      type: 'answer',
+      playerId: 'p1',
+      answerId: '2',
+      powerupType: 'fifty',
+    });
+    expect(g2.state.powerups.p1.fifty).toBe(false);
+  });
+
+  it('rejects unavailable powerup', () => {
+    const game = makeGame(['p1']);
+    const g1 = toQuestion(game);
+    // Use double first
+    const { game: g2 } = processAction(g1, {
+      type: 'answer',
+      playerId: 'p1',
+      answerId: '2',
+      powerupType: 'double',
+    });
+    // Move to next question
+    const g3 = processAction(g2, { type: 'timerExpired', phase: 'question' }).game;
+    const g4 = processAction(g3, { type: 'timerExpired', phase: 'reveal' }).game;
+    const g5 = processAction(g4, { type: 'timerExpired', phase: 'between' }).game;
+    // Try to use double again — should be unavailable
+    const { events } = processAction(g5, {
+      type: 'answer',
+      playerId: 'p1',
+      answerId: 'Paris',
+      powerupType: 'double',
+    });
+    expect(events[0].type).toBe('error');
+    expect(events[0].message).toMatch(/not available/i);
+  });
+
+  it('does not consume powerup of other players', () => {
+    const game = makeGame(['p1', 'p2']);
+    const g1 = toQuestion(game);
+    const { game: g2 } = processAction(g1, {
+      type: 'answer',
+      playerId: 'p1',
+      answerId: '2',
+      powerupType: 'double',
+    });
+    expect(g2.state.powerups.p2.double).toBe(true);
+  });
+});
+
+// -----------------------------------------------------------------------
+// Scoring mechanics (timerExpired question)
+// -----------------------------------------------------------------------
+describe('Quiz - scoring', () => {
+  it('correct answer awards points (>0)', () => {
+    const game = makeGame(['p1']);
+    const g1 = toQuestion(game);
+    const { game: g2 } = processAction(g1, {
+      type: 'answer',
+      playerId: 'p1',
+      answerId: Q1.correct_answer,
+    });
+    const { game: g3 } = processAction(g2, { type: 'timerExpired', phase: 'question' });
+    expect(g3.state.scores.p1).toBeGreaterThan(0);
+  });
+
+  it('wrong answer awards 0 points and resets streak', () => {
+    const game = makeGame(['p1']);
+    const g1 = toQuestion(game);
+    const { game: g2 } = processAction(g1, {
+      type: 'answer',
+      playerId: 'p1',
+      answerId: 'WRONG',
+    });
+    const { game: g3 } = processAction(g2, { type: 'timerExpired', phase: 'question' });
+    expect(g3.state.scores.p1).toBe(0);
+    expect(g3.state.streaks.p1).toBe(0);
+  });
+
+  it('no answer resets streak to 0', () => {
+    const game = makeGame(['p1']);
+    const g1 = toQuestion(game);
+    // No answer submitted — just expire timer
+    const { game: g2 } = processAction(g1, { type: 'timerExpired', phase: 'question' });
+    expect(g2.state.streaks.p1).toBe(0);
+    expect(g2.state.scores.p1).toBe(0);
+  });
+
+  it('correct answer increments streak', () => {
+    const game = makeGame(['p1']);
+    const g1 = toQuestion(game);
+    const { game: g2 } = processAction(g1, {
+      type: 'answer',
+      playerId: 'p1',
+      answerId: Q1.correct_answer,
+    });
+    const { game: g3 } = processAction(g2, { type: 'timerExpired', phase: 'question' });
+    expect(g3.state.streaks.p1).toBe(1);
+  });
+
+  it('double powerup doubles the score', () => {
+    const game = makeGame(['p1', 'p2']);
+    const g1 = toQuestion(game);
+    // p1 uses double, p2 answers without powerup — same answerId
+    const { game: g2 } = processAction(g1, {
+      type: 'answer',
+      playerId: 'p1',
+      answerId: Q1.correct_answer,
+      powerupType: 'double',
+    });
+    const { game: g3 } = processAction(g2, {
+      type: 'answer',
+      playerId: 'p2',
+      answerId: Q1.correct_answer,
+    });
+    const { game: g4 } = processAction(g3, { type: 'timerExpired', phase: 'question' });
+    // p1 should have roughly double p2's score (both answered at nearly same time)
+    expect(g4.state.scores.p1).toBeGreaterThan(g4.state.scores.p2);
+  });
+
+  it('correctPlayers in reveal event contains only correct answerers', () => {
+    const game = makeGame(['p1', 'p2']);
+    const g1 = toQuestion(game);
+    const { game: g2 } = processAction(g1, {
+      type: 'answer',
+      playerId: 'p1',
+      answerId: Q1.correct_answer,
+    });
+    const { game: g3 } = processAction(g2, {
+      type: 'answer',
+      playerId: 'p2',
+      answerId: 'WRONG',
+    });
+    const { events } = processAction(g3, { type: 'timerExpired', phase: 'question' });
+    const revealEvent = events.find(e => e.type === 'phase_change' && e.phase === 'reveal');
+    expect(revealEvent.correctPlayers).toContain('p1');
+    expect(revealEvent.correctPlayers).not.toContain('p2');
+  });
+
+  it('phase_change event includes correctAnswer on question expiry', () => {
+    const game = makeGame(['p1']);
+    const g1 = toQuestion(game);
+    const { events } = processAction(g1, { type: 'timerExpired', phase: 'question' });
+    const ev = events.find(e => e.phase === 'reveal');
+    expect(ev.correctAnswer).toBe(Q1.correct_answer);
+  });
+});
+
+// -----------------------------------------------------------------------
+// timerExpired — all 4 transitions (with action context)
+// -----------------------------------------------------------------------
+describe('Quiz - timerExpired with answer context', () => {
+  it('countdown -> question: answers cleared and questionStartTime set', () => {
+    const game = makeGame(['p1']);
+    // Manually put an answer in state to confirm it gets cleared
+    const { game: g2 } = processAction(game, { type: 'timerExpired', phase: 'countdown' });
+    expect(g2.state.phase).toBe('question');
+    expect(g2.state.answers).toEqual({});
+    expect(g2.state.questionStartTime).not.toBeNull();
+  });
+
+  it('reveal -> between when more questions remain', () => {
+    const game = makeGame(['p1'], [Q1, Q2]);
+    const g1 = toReveal(game);
+    expect(g1.state.phase).toBe('reveal');
+    const { game: g2, events } = processAction(g1, { type: 'timerExpired', phase: 'reveal' });
+    expect(g2.state.phase).toBe('between');
+    expect(g2.state.currentQuestion).toBe(1);
+    expect(events[0].phase).toBe('between');
+  });
+
+  it('reveal -> finished when no more questions', () => {
+    const game = makeGame(['p1'], [Q1]); // only 1 question
+    const g1 = toReveal(game);
+    const { game: g2, events } = processAction(g1, { type: 'timerExpired', phase: 'reveal' });
+    expect(g2.state.phase).toBe('finished');
+    expect(events[0].phase).toBe('finished');
+  });
+
+  it('between -> question: answers cleared, round incremented', () => {
+    const game = makeGame(['p1'], [Q1, Q2]);
+    const g1 = toReveal(game);
+    const g2 = processAction(g1, { type: 'timerExpired', phase: 'reveal' }).game;
+    expect(g2.state.phase).toBe('between');
+    const { game: g3 } = processAction(g2, { type: 'timerExpired', phase: 'between' });
+    expect(g3.state.phase).toBe('question');
+    expect(g3.state.answers).toEqual({});
+    expect(g3.state.round).toBe(1);
+  });
+
+  it('full 2-question cycle reaches finished and endIf returns result', () => {
+    let game = makeGame(['p1'], [Q1, Q2]);
+    game = processAction(game, { type: 'timerExpired', phase: 'countdown' }).game;
+    game = processAction(game, { type: 'timerExpired', phase: 'question' }).game;
+    game = processAction(game, { type: 'timerExpired', phase: 'reveal' }).game;
+    game = processAction(game, { type: 'timerExpired', phase: 'between' }).game;
+    game = processAction(game, { type: 'timerExpired', phase: 'question' }).game;
+    game = processAction(game, { type: 'timerExpired', phase: 'reveal' }).game;
+
+    expect(game.state.phase).toBe('finished');
+    const result = checkEnd(game);
+    expect(result).not.toBeNull();
+    expect(result).toHaveProperty('scores');
+  });
+
+  it('timerExpired for wrong phase is a no-op', () => {
+    const game = makeGame(['p1']);
+    expect(game.state.phase).toBe('countdown');
+    const { game: same, events } = processAction(game, { type: 'timerExpired', phase: 'question' });
+    expect(same.state.phase).toBe('countdown');
+    expect(events).toHaveLength(0);
+  });
+});
+
+// -----------------------------------------------------------------------
+// View filtering
+// -----------------------------------------------------------------------
+describe('Quiz - view filtering', () => {
+  it('shows player their own powerups', () => {
+    const game = makeGame(['p1', 'p2']);
+    const view = getView(game, 'p1');
+    expect(view.myPowerups).toEqual({ double: true, fifty: true, freeze: true });
+  });
+
+  it('shows question data during question phase', () => {
+    const game = makeGame(['p1']);
+    const g1 = toQuestion(game);
+    const view = getView(g1, 'p1');
+    expect(view.question).toBeDefined();
+    expect(view.question.question).toBe(Q1.question);
+    expect(view.question.answers).toHaveLength(4);
+  });
+
+  it('hasAnswered is true after player answers', () => {
+    const game = makeGame(['p1']);
+    const g1 = toQuestion(game);
+    const { game: g2 } = processAction(g1, { type: 'answer', playerId: 'p1', answerId: '2' });
+    const view = getView(g2, 'p1');
+    expect(view.hasAnswered).toBe(true);
+  });
+
+  it('hasAnswered is false before answering', () => {
+    const game = makeGame(['p1']);
+    const g1 = toQuestion(game);
+    const view = getView(g1, 'p1');
+    expect(view.hasAnswered).toBe(false);
+  });
+
+  it('fifty-fifty reduces answers to 2 during question phase', () => {
+    const game = makeGame(['p1']);
+    const g1 = toQuestion(game);
+    const { game: g2 } = processAction(g1, {
+      type: 'answer',
+      playerId: 'p1',
+      answerId: Q1.correct_answer,
+      powerupType: 'fifty',
+    });
+    const view = getView(g2, 'p1');
+    // After fifty-fifty: correct + 1 incorrect = 2 answers
+    expect(view.question.answers).toHaveLength(2);
+    expect(view.question.answers).toContain(Q1.correct_answer);
+  });
+
+  it('reveals correctAnswer during reveal phase', () => {
+    const game = makeGame(['p1']);
+    const g1 = toReveal(game);
+    const view = getView(g1, 'p1');
+    expect(view.correctAnswer).toBe(Q1.correct_answer);
+  });
+
+  it('shows correctPlayers during reveal phase', () => {
+    const game = makeGame(['p1', 'p2']);
+    const g1 = toQuestion(game);
+    const { game: g2 } = processAction(g1, {
+      type: 'answer',
+      playerId: 'p1',
+      answerId: Q1.correct_answer,
+    });
+    const { game: g3 } = processAction(g2, { type: 'timerExpired', phase: 'question' });
+    const view = getView(g3, 'p2');
+    expect(view.correctPlayers).toContain('p1');
+  });
+
+  it('no question data in countdown phase', () => {
+    const game = makeGame(['p1']);
+    const view = getView(game, 'p1');
+    expect(view.question).toBeUndefined();
+  });
+
+  it('finalScores visible in finished phase', () => {
+    let game = makeGame(['p1'], [Q1]);
+    game = processAction(game, { type: 'timerExpired', phase: 'countdown' }).game;
+    game = processAction(game, { type: 'timerExpired', phase: 'question' }).game;
+    game = processAction(game, { type: 'timerExpired', phase: 'reveal' }).game;
+    const view = getView(game, 'p1');
+    expect(view.finalScores).toBeDefined();
+    expect(view.finalScores).toHaveProperty('p1');
+  });
+
+  it('shows total question count', () => {
+    const game = makeGame(['p1'], [Q1, Q2]);
+    const view = getView(game, 'p1');
+    expect(view.totalQuestions).toBe(2);
+  });
+
+  it('shows myStreak for the player', () => {
+    const game = makeGame(['p1']);
+    const g1 = toQuestion(game);
+    const { game: g2 } = processAction(g1, {
+      type: 'answer',
+      playerId: 'p1',
+      answerId: Q1.correct_answer,
+    });
+    const { game: g3 } = processAction(g2, { type: 'timerExpired', phase: 'question' });
+    const view = getView(g3, 'p1');
+    expect(view.myStreak).toBe(1);
+  });
+});
+
+// -----------------------------------------------------------------------
+// endIf
+// -----------------------------------------------------------------------
+describe('Quiz - endIf', () => {
+  it('returns null during active play', () => {
+    const game = makeGame(['p1']);
+    expect(checkEnd(game)).toBeNull();
+  });
+
+  it('returns winner with highest score when finished', () => {
+    const game = makeGame(['p1', 'p2'], [Q1]);
+    let g = processAction(game, { type: 'timerExpired', phase: 'countdown' }).game;
+    // p1 answers correctly
+    g = processAction(g, { type: 'answer', playerId: 'p1', answerId: Q1.correct_answer }).game;
+    g = processAction(g, { type: 'timerExpired', phase: 'question' }).game;
+    g = processAction(g, { type: 'timerExpired', phase: 'reveal' }).game;
+
+    expect(g.state.phase).toBe('finished');
+    const result = checkEnd(g);
+    expect(result.winner).toBe('p1');
+    expect(result.scores.p1).toBeGreaterThan(result.scores.p2);
+  });
+});

--- a/tests/engine/spy.test.js
+++ b/tests/engine/spy.test.js
@@ -1,0 +1,420 @@
+// Unit tests for src/engine/games/spy.js
+// Covers: setup, clue submission, guess scoring, timer phase transitions,
+// per-player view filtering.
+
+import { describe, it, expect } from 'vitest';
+import spy, { SPY_WORDS } from '../../src/engine/games/spy.js';
+import { createGame, processAction, getView, checkEnd } from '../../src/engine/engine.js';
+import { createTestGame, act, actChain, viewFor, isOver } from './game-harness.js';
+
+// Helper: create a spy game with specific config
+function makeGame(players = ['p1', 'p2', 'p3'], config = {}) {
+  return createGame(spy, { players, config });
+}
+
+// Helper: get to the guess phase via timerExpired
+function toGuessPhase(game) {
+  return processAction(game, { type: 'timerExpired', phase: 'clues' }).game;
+}
+
+// Helper: get to the reveal phase
+function toRevealPhase(game, guessText) {
+  const g1 = toGuessPhase(game);
+  return processAction(g1, {
+    type: 'sendGuess',
+    playerId: g1.state.spy,
+    text: guessText ?? g1.state.word,
+  }).game;
+}
+
+// -----------------------------------------------------------------------
+// Setup
+// -----------------------------------------------------------------------
+describe('Spy - setup', () => {
+  it('immediately starts the first round (phase is clues)', () => {
+    const game = makeGame();
+    expect(game.state.phase).toBe('clues');
+  });
+
+  it('assigns a spy from the player list', () => {
+    const game = makeGame(['p1', 'p2', 'p3']);
+    expect(['p1', 'p2', 'p3']).toContain(game.state.spy);
+  });
+
+  it('assigns a word from SPY_WORDS by default', () => {
+    const game = makeGame();
+    expect(SPY_WORDS).toContain(game.state.word);
+  });
+
+  it('uses custom words when provided', () => {
+    const customWords = ['apple', 'orange'];
+    const game = makeGame(['p1', 'p2'], { words: customWords });
+    expect(customWords).toContain(game.state.word);
+  });
+
+  it('uses custom rounds count', () => {
+    const game = makeGame(['p1', 'p2'], { rounds: 5 });
+    expect(game.state.totalRounds).toBe(5);
+  });
+
+  it('defaults to 10 total rounds', () => {
+    const game = makeGame();
+    expect(game.state.totalRounds).toBe(10);
+  });
+
+  it('initialises scores at 0 for all players', () => {
+    const game = makeGame(['p1', 'p2', 'p3']);
+    expect(game.state.scores).toEqual({ p1: 0, p2: 0, p3: 0 });
+  });
+
+  it('round counter starts at 1 (first round already started)', () => {
+    const game = makeGame();
+    expect(game.state.round).toBe(1);
+  });
+
+  it('clues object starts empty', () => {
+    const game = makeGame();
+    expect(game.state.clues).toEqual({});
+  });
+});
+
+// -----------------------------------------------------------------------
+// Clue submission
+// -----------------------------------------------------------------------
+describe('Spy - sendClue', () => {
+  it('records a clue for a non-spy player', () => {
+    const game = makeGame(['p1', 'p2', 'p3']);
+    const nonSpy = game.state.players.find(p => p !== game.state.spy);
+    const { game: g2, events } = processAction(game, {
+      type: 'sendClue',
+      playerId: nonSpy,
+      text: 'ocean',
+    });
+    expect(g2.state.clues[nonSpy]).toBe('ocean');
+    expect(events[0].type).toBe('clue_submitted');
+    expect(events[0].clue).toBe('ocean');
+  });
+
+  it('only records the first word of multi-word text', () => {
+    const game = makeGame(['p1', 'p2']);
+    const nonSpy = game.state.players.find(p => p !== game.state.spy);
+    const { game: g2 } = processAction(game, {
+      type: 'sendClue',
+      playerId: nonSpy,
+      text: 'big ocean',
+    });
+    expect(g2.state.clues[nonSpy]).toBe('big');
+  });
+
+  it('rejects a clue from the spy', () => {
+    const game = makeGame(['p1', 'p2', 'p3']);
+    const { events } = processAction(game, {
+      type: 'sendClue',
+      playerId: game.state.spy,
+      text: 'water',
+    });
+    expect(events[0].type).toBe('error');
+    expect(events[0].message).toMatch(/spy cannot/i);
+  });
+
+  it('rejects a duplicate clue from the same player', () => {
+    const game = makeGame(['p1', 'p2', 'p3']);
+    const nonSpy = game.state.players.find(p => p !== game.state.spy);
+    const { game: g2 } = processAction(game, {
+      type: 'sendClue',
+      playerId: nonSpy,
+      text: 'first',
+    });
+    const { events } = processAction(g2, {
+      type: 'sendClue',
+      playerId: nonSpy,
+      text: 'second',
+    });
+    expect(events[0].type).toBe('error');
+    expect(events[0].message).toMatch(/already submitted/i);
+  });
+
+  it('rejects empty clue text', () => {
+    const game = makeGame(['p1', 'p2', 'p3']);
+    const nonSpy = game.state.players.find(p => p !== game.state.spy);
+    const { events } = processAction(game, {
+      type: 'sendClue',
+      playerId: nonSpy,
+      text: '   ',
+    });
+    expect(events[0].type).toBe('error');
+    expect(events[0].message).toMatch(/empty/i);
+  });
+
+  it('rejects a clue when not in clues phase', () => {
+    const game = makeGame(['p1', 'p2', 'p3']);
+    const g2 = toGuessPhase(game); // now in 'guess' phase
+    const nonSpy = g2.state.players.find(p => p !== g2.state.spy);
+    const { events } = processAction(g2, {
+      type: 'sendClue',
+      playerId: nonSpy,
+      text: 'water',
+    });
+    expect(events[0].type).toBe('error');
+    expect(events[0].message).toMatch(/not in clues/i);
+  });
+});
+
+// -----------------------------------------------------------------------
+// Guess scoring
+// -----------------------------------------------------------------------
+describe('Spy - sendGuess', () => {
+  it('correct guess awards spy 3 points', () => {
+    const game = makeGame(['p1', 'p2', 'p3']);
+    const g1 = toGuessPhase(game);
+    const spyId = g1.state.spy;
+    const { game: g2 } = processAction(g1, {
+      type: 'sendGuess',
+      playerId: spyId,
+      text: g1.state.word,
+    });
+    expect(g2.state.scores[spyId]).toBe(3);
+  });
+
+  it('correct guess sets phase to reveal', () => {
+    const game = makeGame(['p1', 'p2', 'p3']);
+    const g1 = toGuessPhase(game);
+    const { game: g2 } = processAction(g1, {
+      type: 'sendGuess',
+      playerId: g1.state.spy,
+      text: g1.state.word,
+    });
+    expect(g2.state.phase).toBe('reveal');
+  });
+
+  it('emits spy_guessed event with correct:true on right guess', () => {
+    const game = makeGame(['p1', 'p2', 'p3']);
+    const g1 = toGuessPhase(game);
+    const { events } = processAction(g1, {
+      type: 'sendGuess',
+      playerId: g1.state.spy,
+      text: g1.state.word,
+    });
+    expect(events[0].type).toBe('spy_guessed');
+    expect(events[0].correct).toBe(true);
+    expect(events[0].word).toBe(g1.state.word);
+  });
+
+  it('wrong guess awards non-spies 1 point each', () => {
+    const players = ['p1', 'p2', 'p3'];
+    const game = makeGame(players);
+    const g1 = toGuessPhase(game);
+    const spyId = g1.state.spy;
+    const nonSpies = players.filter(p => p !== spyId);
+
+    const { game: g2 } = processAction(g1, {
+      type: 'sendGuess',
+      playerId: spyId,
+      text: 'WRONG_WORD_12345',
+    });
+    for (const pid of nonSpies) {
+      expect(g2.state.scores[pid]).toBe(1);
+    }
+    expect(g2.state.scores[spyId]).toBe(0);
+  });
+
+  it('emits spy_guessed event with correct:false on wrong guess', () => {
+    const game = makeGame(['p1', 'p2', 'p3']);
+    const g1 = toGuessPhase(game);
+    const { events } = processAction(g1, {
+      type: 'sendGuess',
+      playerId: g1.state.spy,
+      text: 'WRONG_WORD_12345',
+    });
+    expect(events[0].correct).toBe(false);
+  });
+
+  it('rejects guess from non-spy player', () => {
+    const game = makeGame(['p1', 'p2', 'p3']);
+    const g1 = toGuessPhase(game);
+    const nonSpy = g1.state.players.find(p => p !== g1.state.spy);
+    const { events } = processAction(g1, {
+      type: 'sendGuess',
+      playerId: nonSpy,
+      text: g1.state.word,
+    });
+    expect(events[0].type).toBe('error');
+    expect(events[0].message).toMatch(/only the spy/i);
+  });
+
+  it('rejects guess when not in guess phase', () => {
+    const game = makeGame(['p1', 'p2', 'p3']);
+    // Still in 'clues' phase
+    const { events } = processAction(game, {
+      type: 'sendGuess',
+      playerId: game.state.spy,
+      text: game.state.word,
+    });
+    expect(events[0].type).toBe('error');
+    expect(events[0].message).toMatch(/not in guess/i);
+  });
+
+  it('comparison is case-insensitive', () => {
+    const game = makeGame(['p1', 'p2', 'p3']);
+    const g1 = toGuessPhase(game);
+    const { game: g2, events } = processAction(g1, {
+      type: 'sendGuess',
+      playerId: g1.state.spy,
+      text: g1.state.word.toUpperCase(),
+    });
+    expect(events[0].correct).toBe(true);
+    expect(g2.state.scores[g1.state.spy]).toBe(3);
+  });
+});
+
+// -----------------------------------------------------------------------
+// timerExpired transitions
+// -----------------------------------------------------------------------
+describe('Spy - timerExpired transitions', () => {
+  it('clues -> guess', () => {
+    const game = makeGame();
+    const { game: g2, events } = processAction(game, { type: 'timerExpired', phase: 'clues' });
+    expect(g2.state.phase).toBe('guess');
+    expect(events[0].type).toBe('phase_change');
+    expect(events[0].phase).toBe('guess');
+  });
+
+  it('guess timeout -> reveal; non-spies get +1 each', () => {
+    const players = ['p1', 'p2', 'p3'];
+    const game = makeGame(players);
+    const g1 = toGuessPhase(game);
+    const spyId = g1.state.spy;
+    const nonSpies = players.filter(p => p !== spyId);
+
+    const { game: g2, events } = processAction(g1, { type: 'timerExpired', phase: 'guess' });
+    expect(g2.state.phase).toBe('reveal');
+    expect(events[0].type).toBe('spy_timeout');
+    for (const pid of nonSpies) {
+      expect(g2.state.scores[pid]).toBe(1);
+    }
+    expect(g2.state.scores[spyId]).toBe(0);
+  });
+
+  it('reveal -> score', () => {
+    const game = makeGame();
+    const g1 = toRevealPhase(game, 'WRONG_WORD_12345');
+    const { game: g2, events } = processAction(g1, { type: 'timerExpired', phase: 'reveal' });
+    expect(g2.state.phase).toBe('score');
+    expect(events[0].phase).toBe('score');
+  });
+
+  it('score -> new_round when rounds remaining', () => {
+    const game = makeGame(['p1', 'p2'], { rounds: 3 });
+    const g1 = toRevealPhase(game, 'WRONG_WORD_12345');
+    const g2 = processAction(g1, { type: 'timerExpired', phase: 'reveal' }).game;
+    const { game: g3, events } = processAction(g2, { type: 'timerExpired', phase: 'score' });
+
+    expect(g3.state.phase).toBe('clues');
+    expect(g3.state.round).toBe(2);
+    expect(events[0].type).toBe('new_round');
+  });
+
+  it('score -> finished when all rounds played', () => {
+    const game = makeGame(['p1', 'p2'], { rounds: 1 });
+    const g1 = toRevealPhase(game, 'WRONG_WORD_12345');
+    const g2 = processAction(g1, { type: 'timerExpired', phase: 'reveal' }).game;
+    const { game: g3, events } = processAction(g2, { type: 'timerExpired', phase: 'score' });
+
+    expect(g3.state.phase).toBe('finished');
+    expect(events[0].phase).toBe('finished');
+  });
+
+  it('ignores timerExpired for wrong phase', () => {
+    const game = makeGame();
+    expect(game.state.phase).toBe('clues');
+    const { game: same, events } = processAction(game, { type: 'timerExpired', phase: 'guess' });
+    expect(same.state.phase).toBe('clues');
+    expect(events).toHaveLength(0);
+  });
+});
+
+// -----------------------------------------------------------------------
+// View filtering
+// -----------------------------------------------------------------------
+describe('Spy - view filtering', () => {
+  it('spy does not see the word', () => {
+    const game = makeGame(['p1', 'p2', 'p3']);
+    const view = getView(game, game.state.spy);
+    expect(view.isSpy).toBe(true);
+    expect(view.word).toBeNull();
+  });
+
+  it('non-spy sees the word', () => {
+    const game = makeGame(['p1', 'p2', 'p3']);
+    const nonSpy = game.state.players.find(p => p !== game.state.spy);
+    const view = getView(game, nonSpy);
+    expect(view.isSpy).toBe(false);
+    expect(view.word).toBe(game.state.word);
+  });
+
+  it('spy is hidden during clues phase', () => {
+    const game = makeGame(['p1', 'p2', 'p3']);
+    const view = getView(game, 'p1');
+    expect(view.spy).toBeNull();
+  });
+
+  it('spy is revealed during reveal phase', () => {
+    const game = makeGame(['p1', 'p2', 'p3']);
+    const g1 = toRevealPhase(game, 'WRONG_WORD_12345');
+    const view = getView(g1, 'p1');
+    expect(view.spy).toBe(g1.state.spy);
+  });
+
+  it('clues visible during guess phase', () => {
+    const game = makeGame(['p1', 'p2', 'p3']);
+    const nonSpy = game.state.players.find(p => p !== game.state.spy);
+    const { game: g2 } = processAction(game, {
+      type: 'sendClue',
+      playerId: nonSpy,
+      text: 'river',
+    });
+    const g3 = toGuessPhase(g2);
+    const view = getView(g3, nonSpy);
+    expect(view.clues[nonSpy]).toBe('river');
+  });
+
+  it('revealedWord and spyGuess visible during reveal phase', () => {
+    const game = makeGame(['p1', 'p2', 'p3']);
+    const g1 = toRevealPhase(game, 'WRONG_WORD_12345');
+    const view = getView(g1, 'p1');
+    expect(view.revealedWord).toBe(g1.state.word);
+    expect(view.spyGuess).toBe('wrong_word_12345');
+  });
+
+  it('finalScores visible in finished phase', () => {
+    const game = makeGame(['p1', 'p2'], { rounds: 1 });
+    const g1 = toRevealPhase(game, 'WRONG_WORD_12345');
+    const g2 = processAction(g1, { type: 'timerExpired', phase: 'reveal' }).game;
+    const g3 = processAction(g2, { type: 'timerExpired', phase: 'score' }).game;
+    expect(g3.state.phase).toBe('finished');
+    const view = getView(g3, 'p1');
+    expect(view.finalScores).toBeDefined();
+  });
+});
+
+// -----------------------------------------------------------------------
+// endIf / full-game
+// -----------------------------------------------------------------------
+describe('Spy - endIf', () => {
+  it('returns null during game play', () => {
+    const game = makeGame();
+    expect(checkEnd(game)).toBeNull();
+  });
+
+  it('returns winner and scores when phase is finished', () => {
+    const game = makeGame(['p1', 'p2'], { rounds: 1 });
+    const g1 = toRevealPhase(game, 'WRONG_WORD_12345');
+    const g2 = processAction(g1, { type: 'timerExpired', phase: 'reveal' }).game;
+    const g3 = processAction(g2, { type: 'timerExpired', phase: 'score' }).game;
+
+    const result = checkEnd(g3);
+    expect(result).not.toBeNull();
+    expect(result).toHaveProperty('winner');
+    expect(result).toHaveProperty('scores');
+  });
+});

--- a/tests/session/manager.test.js
+++ b/tests/session/manager.test.js
@@ -1,0 +1,266 @@
+// Unit tests for src/session/manager.js
+// Covers: room creation (code uniqueness), lookup, cleanup of stale rooms,
+// player-to-room mapping.
+// Uses vi.useFakeTimers() for cleanup interval tests.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { RoomManager } from '../../src/session/manager.js';
+
+// -----------------------------------------------------------------------
+// Helper: create a fresh RoomManager per test (avoid shared singleton state)
+// -----------------------------------------------------------------------
+function makeManager() {
+  return new RoomManager();
+}
+
+// -----------------------------------------------------------------------
+// Room creation
+// -----------------------------------------------------------------------
+describe('RoomManager - createRoom', () => {
+  let manager;
+  afterEach(() => manager.destroy());
+
+  it('returns a Room instance with a code', () => {
+    manager = makeManager();
+    const room = manager.createRoom();
+    expect(room).toBeDefined();
+    expect(typeof room.code).toBe('string');
+    expect(room.code).toHaveLength(4);
+  });
+
+  it('stores the room so it can be retrieved by code', () => {
+    manager = makeManager();
+    const room = manager.createRoom();
+    expect(manager.getRoom(room.code)).toBe(room);
+  });
+
+  it('codes are unique across multiple rooms', () => {
+    manager = makeManager();
+    const codes = new Set();
+    for (let i = 0; i < 20; i++) {
+      codes.add(manager.createRoom().code);
+    }
+    expect(codes.size).toBe(20);
+  });
+
+  it('room count increases with each created room', () => {
+    manager = makeManager();
+    manager.createRoom();
+    manager.createRoom();
+    expect(manager.stats().roomCount).toBe(2);
+  });
+});
+
+// -----------------------------------------------------------------------
+// Lookup
+// -----------------------------------------------------------------------
+describe('RoomManager - getRoom', () => {
+  let manager;
+  afterEach(() => manager.destroy());
+
+  it('returns null for an unknown code', () => {
+    manager = makeManager();
+    expect(manager.getRoom('XXXX')).toBeNull();
+  });
+
+  it('returns the correct room for a known code', () => {
+    manager = makeManager();
+    const room = manager.createRoom();
+    expect(manager.getRoom(room.code)).toBe(room);
+  });
+
+  it('returns null after room is removed', () => {
+    manager = makeManager();
+    const room = manager.createRoom();
+    manager.removeRoom(room.code);
+    expect(manager.getRoom(room.code)).toBeNull();
+  });
+});
+
+// -----------------------------------------------------------------------
+// removeRoom
+// -----------------------------------------------------------------------
+describe('RoomManager - removeRoom', () => {
+  let manager;
+  afterEach(() => manager.destroy());
+
+  it('removes the room by code', () => {
+    manager = makeManager();
+    const room = manager.createRoom();
+    manager.removeRoom(room.code);
+    expect(manager.rooms.has(room.code)).toBe(false);
+  });
+
+  it('is a no-op for non-existent code', () => {
+    manager = makeManager();
+    expect(() => manager.removeRoom('NOPE')).not.toThrow();
+  });
+
+  it('decreases the room count', () => {
+    manager = makeManager();
+    const room = manager.createRoom();
+    manager.removeRoom(room.code);
+    expect(manager.stats().roomCount).toBe(0);
+  });
+});
+
+// -----------------------------------------------------------------------
+// Player-to-room mapping
+// -----------------------------------------------------------------------
+describe('RoomManager - getRoomForPlayer', () => {
+  let manager;
+  afterEach(() => manager.destroy());
+
+  it('returns the room containing a given player', () => {
+    manager = makeManager();
+    const room = manager.createRoom();
+    const { playerId } = room.addPlayer('Alice');
+    expect(manager.getRoomForPlayer(playerId)).toBe(room);
+  });
+
+  it('returns null when player is in no room', () => {
+    manager = makeManager();
+    expect(manager.getRoomForPlayer('ghost')).toBeNull();
+  });
+
+  it('returns correct room when multiple rooms exist', () => {
+    manager = makeManager();
+    const r1 = manager.createRoom();
+    const r2 = manager.createRoom();
+    const { playerId: p1 } = r1.addPlayer('Alice');
+    const { playerId: p2 } = r2.addPlayer('Bob');
+    expect(manager.getRoomForPlayer(p1)).toBe(r1);
+    expect(manager.getRoomForPlayer(p2)).toBe(r2);
+  });
+
+  it('returns null after player is removed from room', () => {
+    manager = makeManager();
+    const room = manager.createRoom();
+    const { playerId } = room.addPlayer('Alice');
+    room.addPlayer('Bob'); // keep room alive
+    room.removePlayer(playerId);
+    expect(manager.getRoomForPlayer(playerId)).toBeNull();
+  });
+});
+
+// -----------------------------------------------------------------------
+// Cleanup — stale rooms
+// -----------------------------------------------------------------------
+describe('RoomManager - cleanup', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('removes empty room after 30 seconds of inactivity', () => {
+    const manager = makeManager();
+    const room = manager.createRoom();
+    // Room is empty — advance past EMPTY_TIMEOUT_MS (30s) + CLEANUP_INTERVAL_MS (60s)
+    vi.advanceTimersByTime(91_000);
+    expect(manager.getRoom(room.code)).toBeNull();
+    manager.destroy();
+  });
+
+  it('keeps empty room within the 30-second window', () => {
+    const manager = makeManager();
+    const room = manager.createRoom();
+    // Only advance 20s (within empty timeout window)
+    vi.advanceTimersByTime(20_000);
+    expect(manager.getRoom(room.code)).toBe(room);
+    manager.destroy();
+  });
+
+  it('removes room idle for more than 4 hours regardless of players', () => {
+    const manager = makeManager();
+    const room = manager.createRoom();
+    room.addPlayer('Alice');
+    // Advance beyond IDLE_TIMEOUT_MS (4h) + one cleanup tick
+    vi.advanceTimersByTime(4 * 60 * 60 * 1000 + 61_000);
+    expect(manager.getRoom(room.code)).toBeNull();
+    manager.destroy();
+  });
+
+  it('keeps a room with recent activity and players', () => {
+    const manager = makeManager();
+    const room = manager.createRoom();
+    room.addPlayer('Alice');
+    // Only advance 30 minutes — well within idle timeout
+    vi.advanceTimersByTime(30 * 60 * 1000);
+    expect(manager.getRoom(room.code)).toBe(room);
+    manager.destroy();
+  });
+
+  it('cleanup respects hasActiveSockets override', () => {
+    const manager = makeManager();
+    const room = manager.createRoom();
+    // Override hasActiveSockets to simulate active socket for this room
+    manager.hasActiveSockets = (code) => code === room.code;
+    // Advance past empty timeout
+    vi.advanceTimersByTime(91_000);
+    // Room should NOT be cleaned up because it has active sockets
+    expect(manager.getRoom(room.code)).toBe(room);
+    manager.destroy();
+  });
+
+  it('cleanup can be triggered manually', () => {
+    const manager = makeManager();
+    const room = manager.createRoom();
+    // Manually set lastActivity far in the past
+    room.lastActivity = Date.now() - (4 * 60 * 60 * 1000 + 1);
+    manager.cleanup();
+    expect(manager.getRoom(room.code)).toBeNull();
+    manager.destroy();
+  });
+});
+
+// -----------------------------------------------------------------------
+// Stats
+// -----------------------------------------------------------------------
+describe('RoomManager - stats', () => {
+  let manager;
+  afterEach(() => manager.destroy());
+
+  it('reports 0 rooms/players/games initially', () => {
+    manager = makeManager();
+    expect(manager.stats()).toEqual({ roomCount: 0, playerCount: 0, gameCount: 0 });
+  });
+
+  it('counts players across rooms', () => {
+    manager = makeManager();
+    const r1 = manager.createRoom();
+    const r2 = manager.createRoom();
+    r1.addPlayer('Alice');
+    r1.addPlayer('Bob');
+    r2.addPlayer('Charlie');
+    expect(manager.stats().playerCount).toBe(3);
+  });
+
+  it('counts running games', async () => {
+    manager = makeManager();
+    const room = manager.createRoom();
+    room.addPlayer('Alice');
+    await room.startGame('number-guess', {});
+    expect(manager.stats().gameCount).toBe(1);
+  });
+
+  it('gameCount decreases after endGame', async () => {
+    manager = makeManager();
+    const room = manager.createRoom();
+    room.addPlayer('Alice');
+    await room.startGame('number-guess', {});
+    room.endGame();
+    expect(manager.stats().gameCount).toBe(0);
+  });
+});
+
+// -----------------------------------------------------------------------
+// destroy
+// -----------------------------------------------------------------------
+describe('RoomManager - destroy', () => {
+  it('stops the cleanup timer without throwing', () => {
+    const manager = makeManager();
+    expect(() => manager.destroy()).not.toThrow();
+  });
+});

--- a/tests/session/room.test.js
+++ b/tests/session/room.test.js
@@ -1,0 +1,435 @@
+// Unit tests for src/session/room.js
+// Covers: player lifecycle (add/remove), admin promotion, ready state,
+// game suggestions, game registry, getState, toJSON.
+// Note: room-voting.test.js covers voting — this file covers core lifecycle.
+
+import { describe, it, expect } from 'vitest';
+import { Room, generateRoomCode } from '../../src/session/room.js';
+
+// -----------------------------------------------------------------------
+// generateRoomCode
+// -----------------------------------------------------------------------
+describe('generateRoomCode', () => {
+  it('returns a 4-character string', () => {
+    expect(generateRoomCode()).toHaveLength(4);
+  });
+
+  it('consists only of valid characters (no I, O, S)', () => {
+    for (let i = 0; i < 50; i++) {
+      const code = generateRoomCode();
+      expect(code).toMatch(/^[ABCDEFGHJKLMNPQRTUVWXYZ0-9]{4}$/);
+      expect(code).not.toMatch(/[IOS]/);
+    }
+  });
+
+  it('produces different codes across calls (probabilistic)', () => {
+    const codes = new Set(Array.from({ length: 20 }, generateRoomCode));
+    expect(codes.size).toBeGreaterThan(1);
+  });
+});
+
+// -----------------------------------------------------------------------
+// Room constructor
+// -----------------------------------------------------------------------
+describe('Room - constructor', () => {
+  it('stores the provided code', () => {
+    const room = new Room('ABCD');
+    expect(room.code).toBe('ABCD');
+  });
+
+  it('starts with no players', () => {
+    const room = new Room('ABCD');
+    expect(room.players.size).toBe(0);
+  });
+
+  it('starts with no game', () => {
+    const room = new Room('ABCD');
+    expect(room.game).toBeNull();
+  });
+
+  it('sets createdAt and lastActivity to recent timestamps', () => {
+    const before = Date.now();
+    const room = new Room('ABCD');
+    const after = Date.now();
+    expect(room.createdAt).toBeGreaterThanOrEqual(before);
+    expect(room.createdAt).toBeLessThanOrEqual(after);
+    expect(room.lastActivity).toBeGreaterThanOrEqual(before);
+  });
+});
+
+// -----------------------------------------------------------------------
+// addPlayer
+// -----------------------------------------------------------------------
+describe('Room - addPlayer', () => {
+  it('returns playerId and avatar', () => {
+    const room = new Room('ABCD');
+    const result = room.addPlayer('Alice');
+    expect(result).toHaveProperty('playerId');
+    expect(result).toHaveProperty('avatar');
+  });
+
+  it('first player becomes admin', () => {
+    const room = new Room('ABCD');
+    const { playerId } = room.addPlayer('Alice');
+    expect(room.players.get(playerId).isAdmin).toBe(true);
+  });
+
+  it('second player is not admin', () => {
+    const room = new Room('ABCD');
+    room.addPlayer('Alice');
+    const { playerId } = room.addPlayer('Bob');
+    expect(room.players.get(playerId).isAdmin).toBe(false);
+  });
+
+  it('player starts with ready: false', () => {
+    const room = new Room('ABCD');
+    const { playerId } = room.addPlayer('Alice');
+    expect(room.players.get(playerId).ready).toBe(false);
+  });
+
+  it('player starts as connected', () => {
+    const room = new Room('ABCD');
+    const { playerId } = room.addPlayer('Alice');
+    expect(room.players.get(playerId).connected).toBe(true);
+  });
+
+  it('player starts as not bot', () => {
+    const room = new Room('ABCD');
+    const { playerId } = room.addPlayer('Alice');
+    expect(room.players.get(playerId).isBot).toBe(false);
+  });
+
+  it('sanitizes username: strips HTML tags', () => {
+    const room = new Room('ABCD');
+    const { playerId } = room.addPlayer('<b>Hack</b>');
+    expect(room.players.get(playerId).username).toBe('Hack');
+  });
+
+  it('sanitizes username: falls back to "Player" for blank input', () => {
+    const room = new Room('ABCD');
+    const { playerId } = room.addPlayer('   ');
+    expect(room.players.get(playerId).username).toBe('Player');
+  });
+
+  it('sanitizes username: truncates to 20 characters', () => {
+    const room = new Room('ABCD');
+    const { playerId } = room.addPlayer('A'.repeat(30));
+    expect(room.players.get(playerId).username).toHaveLength(20);
+  });
+
+  it('deterministic avatar for same username', () => {
+    const r1 = new Room('AAA1');
+    const r2 = new Room('AAA2');
+    const { avatar: a1 } = r1.addPlayer('Alice');
+    const { avatar: a2 } = r2.addPlayer('Alice');
+    expect(a1).toBe(a2);
+  });
+
+  it('updates lastActivity', () => {
+    const room = new Room('ABCD');
+    const before = Date.now();
+    room.addPlayer('Alice');
+    expect(room.lastActivity).toBeGreaterThanOrEqual(before);
+  });
+
+  it('each call produces a unique playerId', () => {
+    const room = new Room('ABCD');
+    const ids = Array.from({ length: 5 }, (_, i) => room.addPlayer(`Player${i}`).playerId);
+    expect(new Set(ids).size).toBe(5);
+  });
+});
+
+// -----------------------------------------------------------------------
+// removePlayer
+// -----------------------------------------------------------------------
+describe('Room - removePlayer', () => {
+  it('removes the player from the map', () => {
+    const room = new Room('ABCD');
+    const { playerId } = room.addPlayer('Alice');
+    room.addPlayer('Bob');
+    room.removePlayer(playerId);
+    expect(room.players.has(playerId)).toBe(false);
+  });
+
+  it('does nothing when player does not exist', () => {
+    const room = new Room('ABCD');
+    room.addPlayer('Alice');
+    expect(() => room.removePlayer('nonexistent')).not.toThrow();
+    expect(room.players.size).toBe(1);
+  });
+
+  it('removes player gameSuggestions entry', () => {
+    const room = new Room('ABCD');
+    const { playerId } = room.addPlayer('Alice');
+    room.addPlayer('Bob');
+    room.gameSuggestions.set(playerId, 'quiz');
+    room.removePlayer(playerId);
+    expect(room.gameSuggestions.has(playerId)).toBe(false);
+  });
+
+  it('updates lastActivity', () => {
+    const room = new Room('ABCD');
+    const { playerId } = room.addPlayer('Alice');
+    room.addPlayer('Bob');
+    const before = Date.now();
+    room.removePlayer(playerId);
+    expect(room.lastActivity).toBeGreaterThanOrEqual(before);
+  });
+});
+
+// -----------------------------------------------------------------------
+// Admin promotion
+// -----------------------------------------------------------------------
+describe('Room - admin promotion', () => {
+  it('promotes first connected player when admin leaves', () => {
+    const room = new Room('ABCD');
+    const { playerId: adminId } = room.addPlayer('Admin');
+    const { playerId: bobId } = room.addPlayer('Bob');
+    room.removePlayer(adminId);
+    expect(room.players.get(bobId).isAdmin).toBe(true);
+  });
+
+  it('promotes first player (even if disconnected) if no one is connected', () => {
+    const room = new Room('ABCD');
+    const { playerId: adminId } = room.addPlayer('Admin');
+    const { playerId: bobId } = room.addPlayer('Bob');
+    // Mark bob as disconnected
+    room.players.get(bobId).connected = false;
+    room.removePlayer(adminId);
+    // Bob should still be promoted (only player)
+    expect(room.players.get(bobId).isAdmin).toBe(true);
+  });
+
+  it('prefers connected players over disconnected for promotion', () => {
+    const room = new Room('ABCD');
+    const { playerId: adminId } = room.addPlayer('Admin');
+    const { playerId: bobId } = room.addPlayer('Bob');
+    const { playerId: charlieId } = room.addPlayer('Charlie');
+    // Bob is disconnected
+    room.players.get(bobId).connected = false;
+    room.removePlayer(adminId);
+    // Charlie should be promoted (connected), not Bob
+    expect(room.players.get(charlieId).isAdmin).toBe(true);
+    expect(room.players.get(bobId).isAdmin).toBe(false);
+  });
+
+  it('no promotion needed when room becomes empty', () => {
+    const room = new Room('ABCD');
+    const { playerId } = room.addPlayer('Admin');
+    room.removePlayer(playerId);
+    expect(room.players.size).toBe(0);
+  });
+
+  it('non-admin removal does not change admin', () => {
+    const room = new Room('ABCD');
+    const { playerId: adminId } = room.addPlayer('Admin');
+    const { playerId: bobId } = room.addPlayer('Bob');
+    room.removePlayer(bobId);
+    expect(room.players.get(adminId).isAdmin).toBe(true);
+  });
+});
+
+// -----------------------------------------------------------------------
+// setReady
+// -----------------------------------------------------------------------
+describe('Room - setReady', () => {
+  it('sets ready to true', () => {
+    const room = new Room('ABCD');
+    const { playerId } = room.addPlayer('Alice');
+    room.setReady(playerId, true);
+    expect(room.players.get(playerId).ready).toBe(true);
+  });
+
+  it('sets ready to false', () => {
+    const room = new Room('ABCD');
+    const { playerId } = room.addPlayer('Alice');
+    room.setReady(playerId, true);
+    room.setReady(playerId, false);
+    expect(room.players.get(playerId).ready).toBe(false);
+  });
+
+  it('does nothing when player does not exist', () => {
+    const room = new Room('ABCD');
+    expect(() => room.setReady('nonexistent', true)).not.toThrow();
+  });
+
+  it('updates lastActivity', () => {
+    const room = new Room('ABCD');
+    const { playerId } = room.addPlayer('Alice');
+    const before = Date.now();
+    room.setReady(playerId, true);
+    expect(room.lastActivity).toBeGreaterThanOrEqual(before);
+  });
+});
+
+// -----------------------------------------------------------------------
+// suggestGame
+// -----------------------------------------------------------------------
+describe('Room - suggestGame', () => {
+  it('records a game suggestion from a player', () => {
+    const room = new Room('ABCD');
+    const { playerId } = room.addPlayer('Alice');
+    room.suggestGame(playerId, 'quiz');
+    expect(room.gameSuggestions.get(playerId)).toBe('quiz');
+  });
+
+  it('overwrites previous suggestion from same player', () => {
+    const room = new Room('ABCD');
+    const { playerId } = room.addPlayer('Alice');
+    room.suggestGame(playerId, 'quiz');
+    room.suggestGame(playerId, 'spy');
+    expect(room.gameSuggestions.get(playerId)).toBe('spy');
+  });
+
+  it('ignores suggestion from non-existent player', () => {
+    const room = new Room('ABCD');
+    room.suggestGame('ghost', 'quiz');
+    expect(room.gameSuggestions.has('ghost')).toBe(false);
+  });
+
+  it('updates lastActivity', () => {
+    const room = new Room('ABCD');
+    const { playerId } = room.addPlayer('Alice');
+    const before = Date.now();
+    room.suggestGame(playerId, 'quiz');
+    expect(room.lastActivity).toBeGreaterThanOrEqual(before);
+  });
+});
+
+// -----------------------------------------------------------------------
+// getState
+// -----------------------------------------------------------------------
+describe('Room - getState', () => {
+  it('returns the room code', () => {
+    const room = new Room('TEST');
+    expect(room.getState().code).toBe('TEST');
+  });
+
+  it('includes all players in array form', () => {
+    const room = new Room('TEST');
+    room.addPlayer('Alice');
+    room.addPlayer('Bob');
+    const { players } = room.getState();
+    expect(players).toHaveLength(2);
+    expect(players[0]).toHaveProperty('playerId');
+    expect(players[0]).toHaveProperty('username');
+  });
+
+  it('gameRunning is false when no game', () => {
+    const room = new Room('TEST');
+    room.addPlayer('Alice');
+    expect(room.getState().gameRunning).toBe(false);
+  });
+
+  it('gameRunning is true when game is set', () => {
+    const room = new Room('TEST');
+    room.addPlayer('Alice');
+    room.game = { id: 'fake' };
+    expect(room.getState().gameRunning).toBe(true);
+  });
+
+  it('includes gameSuggestions as object', () => {
+    const room = new Room('TEST');
+    const { playerId } = room.addPlayer('Alice');
+    room.suggestGame(playerId, 'spy');
+    const state = room.getState();
+    expect(state.gameSuggestions[playerId]).toBe('spy');
+  });
+});
+
+// -----------------------------------------------------------------------
+// startGame — game registry
+// -----------------------------------------------------------------------
+describe('Room - startGame (registry)', () => {
+  it('throws for an unknown game type', async () => {
+    const room = new Room('TEST');
+    room.addPlayer('Alice');
+    await expect(room.startGame('unknown-game', {})).rejects.toThrow(/Unknown game type/);
+  });
+
+  it('throws when no connected players', async () => {
+    const room = new Room('TEST');
+    const { playerId } = room.addPlayer('Alice');
+    room.players.get(playerId).connected = false;
+    await expect(room.startGame('number-guess', {})).rejects.toThrow(/No connected players/);
+  });
+
+  it('can start number-guess (sync setup, no prepare)', async () => {
+    const room = new Room('TEST');
+    room.addPlayer('Alice');
+    const game = await room.startGame('number-guess', {});
+    expect(game).toBeDefined();
+    expect(room.game).toBe(game);
+  });
+
+  it('clears gameSuggestions after starting a game', async () => {
+    const room = new Room('TEST');
+    const { playerId } = room.addPlayer('Alice');
+    room.suggestGame(playerId, 'quiz');
+    await room.startGame('number-guess', {});
+    expect(room.gameSuggestions.size).toBe(0);
+  });
+});
+
+// -----------------------------------------------------------------------
+// endGame
+// -----------------------------------------------------------------------
+describe('Room - endGame', () => {
+  it('clears the game reference', async () => {
+    const room = new Room('TEST');
+    room.addPlayer('Alice');
+    await room.startGame('number-guess', {});
+    room.endGame();
+    expect(room.game).toBeNull();
+  });
+
+  it('resets all ready states', async () => {
+    const room = new Room('TEST');
+    const { playerId } = room.addPlayer('Alice');
+    room.setReady(playerId, true);
+    await room.startGame('number-guess', {});
+    room.endGame();
+    expect(room.players.get(playerId).ready).toBe(false);
+  });
+
+  it('updates lastActivity', () => {
+    const room = new Room('TEST');
+    room.game = { id: 'fake' };
+    const before = Date.now();
+    room.endGame();
+    expect(room.lastActivity).toBeGreaterThanOrEqual(before);
+  });
+});
+
+// -----------------------------------------------------------------------
+// toJSON
+// -----------------------------------------------------------------------
+describe('Room - toJSON', () => {
+  it('returns code and language', () => {
+    const room = new Room('JSON');
+    const json = room.toJSON();
+    expect(json.code).toBe('JSON');
+    expect(json).toHaveProperty('language');
+  });
+
+  it('includes players as plain object keyed by playerId', () => {
+    const room = new Room('JSON');
+    const { playerId } = room.addPlayer('Alice');
+    const json = room.toJSON();
+    expect(json.players).toHaveProperty(playerId);
+    expect(json.players[playerId].username).toBe('Alice');
+  });
+
+  it('game is null when no game running', () => {
+    const room = new Room('JSON');
+    expect(room.toJSON().game).toBeNull();
+  });
+
+  it('game contains id when a game is running', async () => {
+    const room = new Room('JSON');
+    room.addPlayer('Alice');
+    const game = await room.startGame('number-guess', {});
+    const json = room.toJSON();
+    expect(json.game.id).toBe(game.id);
+  });
+});

--- a/tests/transport/ws-adapter.test.js
+++ b/tests/transport/ws-adapter.test.js
@@ -1,0 +1,546 @@
+// Unit tests for src/transport/ws-adapter.js
+// Covers: message dispatch, rate limiting, reconnection grace period.
+// WebSocket layer is fully mocked — no real HTTP server.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// -----------------------------------------------------------------------
+// Mock 'ws' module BEFORE importing the adapter
+// -----------------------------------------------------------------------
+
+// We need a controllable fake WebSocketServer.
+// The adapter calls: new WebSocketServer({ server }), wss.on('connection', ...), wss.on('close', ...)
+// and individual ws objects need: ws.readyState, ws.OPEN, ws.send(), ws.ping(), ws.terminate(),
+// ws.on('message',...), ws.on('close',...), ws.on('pong',...), ws.on('error',...)
+
+function makeFakeWs(roomCode = 'TEST', role = 'player') {
+  const listeners = {};
+  const sent = [];
+  const ws = {
+    readyState: 1, // OPEN
+    OPEN: 1,
+    send: vi.fn((data) => sent.push(JSON.parse(data))),
+    ping: vi.fn(),
+    terminate: vi.fn(),
+    close: vi.fn(),
+    _sent: sent,
+    on(event, handler) {
+      listeners[event] = handler;
+      return this;
+    },
+    emit(event, ...args) {
+      if (listeners[event]) listeners[event](...args);
+    },
+    // Simulate a URL for the adapter's URL parsing
+    _url: `/ws/${role}/${roomCode}`,
+    _host: 'localhost',
+  };
+  return ws;
+}
+
+function makeFakeReq(url, host = 'localhost') {
+  return {
+    url,
+    headers: { host },
+  };
+}
+
+// Shared fake WebSocketServer
+let wssListeners = {};
+const fakeWss = {
+  on(event, handler) {
+    wssListeners[event] = handler;
+    return this;
+  },
+  emit(event, ...args) {
+    if (wssListeners[event]) wssListeners[event](...args);
+  },
+};
+
+vi.mock('ws', () => ({
+  WebSocketServer: vi.fn(() => fakeWss),
+}));
+
+// Mock fetchers (quiz.js imports cached-fetcher, ws-adapter imports cached-fetcher too)
+vi.mock('../../src/fetcher/cached-fetcher.js', () => ({
+  fetchQuestions: vi.fn(),
+  fetchCategories: vi.fn().mockResolvedValue({
+    ok: true,
+    categories: [{ id: 9, name: 'General Knowledge' }],
+  }),
+}));
+
+vi.mock('../../src/fetcher/question-file.js', () => ({
+  saveAnswers: vi.fn().mockResolvedValue(undefined),
+}));
+
+// -----------------------------------------------------------------------
+// Now import the module under test
+// -----------------------------------------------------------------------
+import { setupWebSocket } from '../../src/transport/ws-adapter.js';
+import { RoomManager } from '../../src/session/manager.js';
+
+// -----------------------------------------------------------------------
+// Test helpers
+// -----------------------------------------------------------------------
+function makeEnv() {
+  // Reset the WSS listener registry each time
+  wssListeners = {};
+
+  const manager = new RoomManager();
+  const room = manager.createRoom();
+  const fakeServer = {}; // adapter just passes this to new WebSocketServer({ server })
+
+  const { wss, broadcastToRoom, sendToPlayer } = setupWebSocket(fakeServer, manager);
+
+  return { manager, room, wss: fakeWss, broadcastToRoom, sendToPlayer };
+}
+
+/** Simulate a connection + JOIN_LOBBY for a player. Returns { ws, meta-like info }. */
+function connectPlayer(env, username, roomCode) {
+  const { room } = env;
+  const code = roomCode || room.code;
+  const ws = makeFakeWs(code, 'player');
+  const req = makeFakeReq(`/ws/player/${code}`, 'localhost');
+  fakeWss.emit('connection', ws, req);
+
+  // Send JOIN_LOBBY
+  ws.emit('message', JSON.stringify({ type: 'JOIN_LOBBY', username }));
+  return ws;
+}
+
+/** Grab the playerId from the JOIN_OK response. */
+function getPlayerId(ws) {
+  const joinOk = ws._sent.find(m => m.type === 'JOIN_OK');
+  return joinOk ? joinOk.playerId : null;
+}
+
+// -----------------------------------------------------------------------
+// Connection handling
+// -----------------------------------------------------------------------
+describe('ws-adapter - connection handling', () => {
+  let env;
+  afterEach(() => env.manager.destroy());
+
+  it('sends LOBBY_UPDATE on connect', () => {
+    env = makeEnv();
+    const ws = makeFakeWs(env.room.code, 'player');
+    fakeWss.emit('connection', ws, makeFakeReq(`/ws/player/${env.room.code}`));
+    const lobbyUpdate = ws._sent.find(m => m.type === 'LOBBY_UPDATE');
+    expect(lobbyUpdate).toBeDefined();
+  });
+
+  it('sends DISPLAY_OK + LOBBY_UPDATE for host role', () => {
+    env = makeEnv();
+    const ws = makeFakeWs(env.room.code, 'host');
+    fakeWss.emit('connection', ws, makeFakeReq(`/ws/host/${env.room.code}`));
+    expect(ws._sent.find(m => m.type === 'DISPLAY_OK')).toBeDefined();
+    expect(ws._sent.find(m => m.type === 'LOBBY_UPDATE')).toBeDefined();
+  });
+
+  it('closes connection for invalid path', () => {
+    env = makeEnv();
+    const ws = makeFakeWs('', 'player');
+    fakeWss.emit('connection', ws, makeFakeReq('/invalid'));
+    expect(ws.close).toHaveBeenCalled();
+  });
+
+  it('closes connection for invalid role', () => {
+    env = makeEnv();
+    const ws = makeFakeWs(env.room.code, 'spectator');
+    fakeWss.emit('connection', ws, makeFakeReq(`/ws/spectator/${env.room.code}`));
+    expect(ws.close).toHaveBeenCalled();
+  });
+
+  it('closes connection when room not found', () => {
+    env = makeEnv();
+    const ws = makeFakeWs('ZZZZ', 'player');
+    fakeWss.emit('connection', ws, makeFakeReq('/ws/player/ZZZZ'));
+    expect(ws.close).toHaveBeenCalled();
+    const errMsg = ws._sent.find(m => m.type === 'ERROR');
+    expect(errMsg).toBeDefined();
+    expect(errMsg.message).toMatch(/Room not found/i);
+  });
+});
+
+// -----------------------------------------------------------------------
+// JOIN_LOBBY
+// -----------------------------------------------------------------------
+describe('ws-adapter - JOIN_LOBBY', () => {
+  let env;
+  afterEach(() => env.manager.destroy());
+
+  it('sends JOIN_OK with playerId and avatar', () => {
+    env = makeEnv();
+    const ws = connectPlayer(env, 'Alice');
+    const joinOk = ws._sent.find(m => m.type === 'JOIN_OK');
+    expect(joinOk).toBeDefined();
+    expect(joinOk.playerId).toBeTruthy();
+    expect(joinOk.avatar).toBeTruthy();
+  });
+
+  it('adds player to room', () => {
+    env = makeEnv();
+    connectPlayer(env, 'Alice');
+    expect(env.room.players.size).toBe(1);
+  });
+
+  it('returns ERROR if username is missing', () => {
+    env = makeEnv();
+    const ws = makeFakeWs(env.room.code, 'player');
+    fakeWss.emit('connection', ws, makeFakeReq(`/ws/player/${env.room.code}`));
+    ws.emit('message', JSON.stringify({ type: 'JOIN_LOBBY' }));
+    const err = ws._sent.find(m => m.type === 'ERROR');
+    expect(err).toBeDefined();
+    expect(err.message).toMatch(/username required/i);
+  });
+
+  it('reconnects existing player by username', () => {
+    env = makeEnv();
+    const ws1 = connectPlayer(env, 'Alice');
+    const playerId1 = getPlayerId(ws1);
+
+    // Simulate disconnect
+    ws1.emit('close');
+
+    // Reconnect with same username on new socket
+    const ws2 = connectPlayer(env, 'Alice');
+    const playerId2 = getPlayerId(ws2);
+
+    expect(playerId2).toBe(playerId1);
+    expect(env.room.players.size).toBe(1);
+  });
+
+  it('broadcasts LOBBY_UPDATE to room after join', () => {
+    env = makeEnv();
+    // Connect a host first so we can observe broadcasts
+    const hostWs = makeFakeWs(env.room.code, 'host');
+    fakeWss.emit('connection', hostWs, makeFakeReq(`/ws/host/${env.room.code}`));
+    const sentBefore = hostWs._sent.length;
+
+    connectPlayer(env, 'Alice');
+
+    const updates = hostWs._sent.slice(sentBefore).filter(m => m.type === 'LOBBY_UPDATE');
+    expect(updates.length).toBeGreaterThan(0);
+  });
+});
+
+// -----------------------------------------------------------------------
+// SET_READY
+// -----------------------------------------------------------------------
+describe('ws-adapter - SET_READY', () => {
+  let env;
+  afterEach(() => env.manager.destroy());
+
+  it('updates player ready state', () => {
+    env = makeEnv();
+    const ws = connectPlayer(env, 'Alice');
+    const playerId = getPlayerId(ws);
+    ws.emit('message', JSON.stringify({ type: 'SET_READY', ready: true }));
+    expect(env.room.players.get(playerId).ready).toBe(true);
+  });
+
+  it('returns ERROR if not yet joined', () => {
+    env = makeEnv();
+    const ws = makeFakeWs(env.room.code, 'player');
+    fakeWss.emit('connection', ws, makeFakeReq(`/ws/player/${env.room.code}`));
+    ws.emit('message', JSON.stringify({ type: 'SET_READY', ready: true }));
+    const err = ws._sent.find(m => m.type === 'ERROR' && /not joined/i.test(m.message));
+    expect(err).toBeDefined();
+  });
+});
+
+// -----------------------------------------------------------------------
+// SUGGEST_GAME
+// -----------------------------------------------------------------------
+describe('ws-adapter - SUGGEST_GAME', () => {
+  let env;
+  afterEach(() => env.manager.destroy());
+
+  it('records game suggestion', () => {
+    env = makeEnv();
+    const ws = connectPlayer(env, 'Alice');
+    const playerId = getPlayerId(ws);
+    ws.emit('message', JSON.stringify({ type: 'SUGGEST_GAME', gameType: 'spy' }));
+    expect(env.room.gameSuggestions.get(playerId)).toBe('spy');
+  });
+
+  it('returns ERROR if gameType missing', () => {
+    env = makeEnv();
+    const ws = connectPlayer(env, 'Alice');
+    ws.emit('message', JSON.stringify({ type: 'SUGGEST_GAME' }));
+    const err = ws._sent.find(m => m.type === 'ERROR' && /gameType required/i.test(m.message));
+    expect(err).toBeDefined();
+  });
+});
+
+// -----------------------------------------------------------------------
+// Message dispatch — unknown type
+// -----------------------------------------------------------------------
+describe('ws-adapter - message dispatch', () => {
+  let env;
+  afterEach(() => env.manager.destroy());
+
+  it('returns ERROR for unknown message type', () => {
+    env = makeEnv();
+    const ws = connectPlayer(env, 'Alice');
+    ws.emit('message', JSON.stringify({ type: 'TOTALLY_UNKNOWN' }));
+    const err = ws._sent.find(m => m.type === 'ERROR' && /unknown message type/i.test(m.message));
+    expect(err).toBeDefined();
+  });
+
+  it('returns ERROR for invalid JSON', () => {
+    env = makeEnv();
+    const ws = makeFakeWs(env.room.code, 'player');
+    fakeWss.emit('connection', ws, makeFakeReq(`/ws/player/${env.room.code}`));
+    ws.emit('message', 'not-valid-json{{{');
+    const err = ws._sent.find(m => m.type === 'ERROR' && /invalid json/i.test(m.message));
+    expect(err).toBeDefined();
+  });
+
+  it('returns ERROR for message missing type', () => {
+    env = makeEnv();
+    const ws = makeFakeWs(env.room.code, 'player');
+    fakeWss.emit('connection', ws, makeFakeReq(`/ws/player/${env.room.code}`));
+    ws.emit('message', JSON.stringify({ data: 'no type here' }));
+    const err = ws._sent.find(m => m.type === 'ERROR' && /missing message type/i.test(m.message));
+    expect(err).toBeDefined();
+  });
+});
+
+// -----------------------------------------------------------------------
+// Rate limiting
+// -----------------------------------------------------------------------
+describe('ws-adapter - rate limiting', () => {
+  let env;
+  afterEach(() => {
+    vi.useRealTimers();
+    env.manager.destroy();
+  });
+
+  it('allows up to RATE_LIMIT_MAX (30) messages per second', () => {
+    vi.useFakeTimers();
+    env = makeEnv();
+    const ws = connectPlayer(env, 'Alice');
+
+    let errors = 0;
+    // Send 35 messages — first 30 should pass, rest should be rate-limited
+    for (let i = 0; i < 35; i++) {
+      ws.emit('message', JSON.stringify({ type: 'SUGGEST_GAME', gameType: 'spy' }));
+    }
+    errors = ws._sent.filter(m => m.type === 'ERROR' && /rate limit/i.test(m.message)).length;
+    expect(errors).toBeGreaterThan(0);
+  });
+
+  it('rate limit resets after the window expires', () => {
+    vi.useFakeTimers();
+    env = makeEnv();
+    const ws = connectPlayer(env, 'Alice');
+
+    // Saturate the rate limit
+    for (let i = 0; i < 31; i++) {
+      ws.emit('message', JSON.stringify({ type: 'SUGGEST_GAME', gameType: 'spy' }));
+    }
+    const errsBefore = ws._sent.filter(m => m.type === 'ERROR' && /rate limit/i.test(m.message)).length;
+    expect(errsBefore).toBeGreaterThan(0);
+
+    // Advance past the 1-second window
+    vi.advanceTimersByTime(1100);
+
+    // Should now accept messages again — send one more
+    ws.emit('message', JSON.stringify({ type: 'SUGGEST_GAME', gameType: 'spy' }));
+    const errsAfter = ws._sent.filter(m => m.type === 'ERROR' && /rate limit/i.test(m.message)).length;
+    // No new rate-limit errors were added after the window reset
+    expect(errsAfter).toBe(errsBefore);
+  });
+
+  it('chat rate limit restricts to CHAT_RATE_MAX (3) per 5 seconds', () => {
+    vi.useFakeTimers();
+    env = makeEnv();
+    const ws = connectPlayer(env, 'Alice');
+
+    // Send 5 chat messages in a row — 4th and 5th should be rate-limited
+    for (let i = 0; i < 5; i++) {
+      ws.emit('message', JSON.stringify({ type: 'CHAT_MESSAGE', text: `msg ${i}` }));
+    }
+    const chatErrors = ws._sent.filter(
+      m => m.type === 'ERROR' && /chat rate limit/i.test(m.message)
+    ).length;
+    expect(chatErrors).toBeGreaterThan(0);
+  });
+});
+
+// -----------------------------------------------------------------------
+// Reconnection grace period
+// -----------------------------------------------------------------------
+describe('ws-adapter - reconnection grace period', () => {
+  let env;
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    env.manager.destroy();
+  });
+
+  it('player marked as disconnected immediately on close, not removed', () => {
+    env = makeEnv();
+    const ws = connectPlayer(env, 'Alice');
+    const playerId = getPlayerId(ws);
+    ws.emit('close');
+
+    const player = env.room.players.get(playerId);
+    expect(player).toBeDefined();
+    expect(player.connected).toBe(false);
+  });
+
+  it('player still in room during 30-second grace window', () => {
+    env = makeEnv();
+    const ws = connectPlayer(env, 'Alice');
+    const playerId = getPlayerId(ws);
+    ws.emit('close');
+
+    vi.advanceTimersByTime(15_000); // half the grace period
+    expect(env.room.players.has(playerId)).toBe(true);
+  });
+
+  it('player removed after 30-second grace period expires', () => {
+    env = makeEnv();
+    const ws = connectPlayer(env, 'Alice');
+    const playerId = getPlayerId(ws);
+    ws.emit('close');
+
+    vi.advanceTimersByTime(31_000); // past the grace period
+    expect(env.room.players.has(playerId)).toBe(false);
+  });
+
+  it('reconnect before grace period cancels removal', () => {
+    env = makeEnv();
+    const ws1 = connectPlayer(env, 'Alice');
+    const playerId = getPlayerId(ws1);
+    ws1.emit('close');
+
+    // Reconnect within the 30-second window
+    vi.advanceTimersByTime(15_000);
+    connectPlayer(env, 'Alice'); // same username → reconnection
+
+    // Advance past the original grace period deadline
+    vi.advanceTimersByTime(20_000);
+
+    // Player should still be in the room (grace timer was cancelled)
+    expect(env.room.players.has(playerId)).toBe(true);
+    expect(env.room.players.get(playerId).connected).toBe(true);
+  });
+
+  it('broadcasts LOBBY_UPDATE when player disconnects', () => {
+    env = makeEnv();
+    // Connect a second player to observe broadcast
+    const ws1 = connectPlayer(env, 'Alice');
+    const ws2 = connectPlayer(env, 'Bob');
+    const sentBefore = ws2._sent.length;
+
+    ws1.emit('close');
+
+    const updates = ws2._sent.slice(sentBefore).filter(m => m.type === 'LOBBY_UPDATE');
+    expect(updates.length).toBeGreaterThan(0);
+  });
+
+  it('broadcasts LOBBY_UPDATE when player is removed after grace period', () => {
+    env = makeEnv();
+    const ws1 = connectPlayer(env, 'Alice');
+    const ws2 = connectPlayer(env, 'Bob');
+    ws1.emit('close');
+
+    const sentBefore = ws2._sent.length;
+    vi.advanceTimersByTime(31_000);
+
+    const updates = ws2._sent.slice(sentBefore).filter(m => m.type === 'LOBBY_UPDATE');
+    expect(updates.length).toBeGreaterThan(0);
+  });
+});
+
+// -----------------------------------------------------------------------
+// GAME_ACTION dispatch
+// -----------------------------------------------------------------------
+describe('ws-adapter - GAME_ACTION', () => {
+  let env;
+  afterEach(() => env.manager.destroy());
+
+  it('returns ERROR when no game is running', () => {
+    env = makeEnv();
+    const ws = connectPlayer(env, 'Alice');
+    ws.emit('message', JSON.stringify({
+      type: 'GAME_ACTION',
+      action: { type: 'increment' },
+    }));
+    const err = ws._sent.find(m => m.type === 'ERROR' && /no game running/i.test(m.message));
+    expect(err).toBeDefined();
+  });
+
+  it('returns ERROR when action type is missing', () => {
+    env = makeEnv();
+    const ws = connectPlayer(env, 'Alice');
+    ws.emit('message', JSON.stringify({
+      type: 'GAME_ACTION',
+      action: {},
+    }));
+    const err = ws._sent.find(m => m.type === 'ERROR');
+    expect(err).toBeDefined();
+  });
+
+  it('processes a valid game action and sends GAME_STATE', async () => {
+    env = makeEnv();
+    const ws = connectPlayer(env, 'Alice');
+
+    // Start number-guess directly on the room
+    await env.room.startGame('number-guess', {});
+
+    // Send a guess action
+    ws.emit('message', JSON.stringify({
+      type: 'GAME_ACTION',
+      action: { type: 'guess', number: 50 },
+    }));
+
+    const gameStates = ws._sent.filter(m => m.type === 'GAME_STATE');
+    expect(gameStates.length).toBeGreaterThan(0);
+  });
+});
+
+// -----------------------------------------------------------------------
+// RETURN_TO_LOBBY
+// -----------------------------------------------------------------------
+describe('ws-adapter - RETURN_TO_LOBBY', () => {
+  let env;
+  afterEach(() => env.manager.destroy());
+
+  it('returns ERROR when not joined', () => {
+    env = makeEnv();
+    const ws = makeFakeWs(env.room.code, 'player');
+    fakeWss.emit('connection', ws, makeFakeReq(`/ws/player/${env.room.code}`));
+    ws.emit('message', JSON.stringify({ type: 'RETURN_TO_LOBBY' }));
+    const err = ws._sent.find(m => m.type === 'ERROR' && /not joined/i.test(m.message));
+    expect(err).toBeDefined();
+  });
+
+  it('returns ERROR when player is not admin', () => {
+    env = makeEnv();
+    connectPlayer(env, 'Admin');    // first → admin
+    const ws2 = connectPlayer(env, 'Bob'); // second → not admin
+    ws2.emit('message', JSON.stringify({ type: 'RETURN_TO_LOBBY' }));
+    const err = ws2._sent.find(m => m.type === 'ERROR' && /only admin/i.test(m.message));
+    expect(err).toBeDefined();
+  });
+
+  it('admin can return to lobby and triggers LOBBY_UPDATE', async () => {
+    env = makeEnv();
+    const ws = connectPlayer(env, 'Admin');
+    await env.room.startGame('number-guess', {});
+    expect(env.room.game).not.toBeNull();
+
+    ws.emit('message', JSON.stringify({ type: 'RETURN_TO_LOBBY' }));
+    expect(env.room.game).toBeNull();
+
+    const update = ws._sent.find(m => m.type === 'LOBBY_UPDATE');
+    expect(update).toBeDefined();
+  });
+});


### PR DESCRIPTION
- tests/engine/engine.test.js: createGame, processAction, getView, checkEnd incl. error paths (20 tests)
- tests/engine/spy.test.js: setup, clue submission, guess scoring, timer transitions, view filtering (38 tests)
- tests/engine/quiz.test.js: answer/powerup submission, scoring, all 4 timer transitions, view filtering (39 tests)
- tests/session/room.test.js: player lifecycle, admin promotion, ready state, game registry (52 tests)
- tests/session/manager.test.js: room creation, lookup, cleanup w/ fake timers, player mapping (25 tests)
- tests/transport/ws-adapter.test.js: message dispatch, rate limiting, reconnect grace period (32 tests)

All 456 tests pass (was 250).