### PR TITLE
fix(quiz): reset per-question state, repair powerup flow, render all phases

### DIFF
--- a/public/host.html
+++ b/public/host.html
@@ -870,6 +870,32 @@
       const content = document.getElementById('gameContent');
       const timerContainer = document.getElementById('timerContainer');
       const timerBar = document.getElementById('timerBar');
+      const roundInfo = document.getElementById('roundInfo');
+
+      // Progress indicator ("Question 3 of 10")
+      if (msg.currentQuestion != null && msg.totalQuestions) {
+        roundInfo.textContent = 'Question ' + (msg.currentQuestion + 1) + ' of ' + msg.totalQuestions;
+      }
+
+      if (msg.phase === 'countdown') {
+        timerContainer.style.display = 'none';
+        content.innerHTML = '<div class="quiz-display">' +
+          '<div class="quiz-question-text">Get ready!</div>' +
+          '<div class="quiz-timer-large">&#9201;</div>' +
+          '<div style="color:var(--text-secondary);">First question coming up...</div>' +
+          '</div>';
+        return;
+      }
+
+      if (msg.phase === 'between') {
+        timerContainer.style.display = 'none';
+        const nextQ = (msg.currentQuestion != null ? msg.currentQuestion + 1 : '?');
+        content.innerHTML = '<div class="quiz-display">' +
+          '<div class="quiz-question-text">Next up: Question ' + nextQ + '</div>' +
+          '<div style="color:var(--text-secondary);margin-top:16px;">Get ready for the next round...</div>' +
+          '</div>';
+        return;
+      }
 
       if (msg.phase === 'question') {
         const q = msg.question || {};
@@ -880,8 +906,7 @@
         const labels = ['A', 'B', 'C', 'D'];
         const classes = ['a', 'b', 'c', 'd'];
         (q.answers || []).forEach((a, i) => {
-          const eliminated = (msg.eliminated || []).includes(i) ? ' eliminated' : '';
-          html += '<div class="quiz-answer-box ' + classes[i] + eliminated + '">' +
+          html += '<div class="quiz-answer-box ' + classes[i] + '">' +
             '<strong>' + labels[i] + '.</strong> ' + escapeHtml(a) + '</div>';
         });
 

--- a/public/player.html
+++ b/public/player.html
@@ -734,7 +734,7 @@
       <div class="answer-grid" id="quizAnswers"></div>
       <div class="powerup-row" id="quizPowerups">
         <button class="powerup-btn" id="pwDouble" onclick="usePowerup('double')">&#10006;2 Double</button>
-        <button class="powerup-btn" id="pw5050" onclick="usePowerup('5050')">50/50</button>
+        <button class="powerup-btn" id="pwFifty" onclick="usePowerup('fifty')">50/50</button>
         <button class="powerup-btn" id="pwFreeze" onclick="usePowerup('freeze')">&#10052; Freeze</button>
       </div>
       <div class="my-score" id="quizScore" style="display:none;">
@@ -928,8 +928,10 @@
       isSpy: false,
       myIndex: -1,
       selectedAnswer: null,
-      powerupsUsed: { double: false, '5050': false, freeze: false },
+      powerupsUsed: { double: false, fifty: false, freeze: false },
       eliminatedAnswers: [],
+      pendingPowerup: null,
+      lastQuizQuestionId: null,
       guessHistory: [],
       reconnectAttempts: 0,
       maxReconnect: 10,
@@ -1065,8 +1067,10 @@
           state.gameType = msg.gameType;
           state.selectedAnswer = null;
           state.eliminatedAnswers = [];
+          state.pendingPowerup = null;
+          state.lastQuizQuestionId = null;
           state.guessHistory = [];
-          state.powerupsUsed = { double: false, '5050': false, freeze: false };
+          state.powerupsUsed = { double: false, fifty: false, freeze: false };
           showSection(getGameSectionId(msg.gameType));
           showToast('Game starting!', 'success');
           break;
@@ -1366,14 +1370,59 @@
     }
 
     // --- Quiz ---
+    const QUIZ_POWERUP_BTNS = { double: 'pwDouble', fifty: 'pwFifty', freeze: 'pwFreeze' };
+
     function renderQuizState(msg) {
       const timerContainer = document.getElementById('quizTimerContainer');
       const timerBar = document.getElementById('quizTimerBar');
       const timerText = document.getElementById('quizTimerText');
+      const questionEl = document.getElementById('quizQuestion');
+      const grid = document.getElementById('quizAnswers');
+      const powerupsEl = document.getElementById('quizPowerups');
 
-      if (msg.phase === 'question') {
-        const q = msg.question || {};
-        document.getElementById('quizQuestion').textContent = q.text || '';
+      // Reset per-question state when a new question arrives
+      const q = msg.question || null;
+      if (q && q.id && q.id !== state.lastQuizQuestionId) {
+        state.selectedAnswer = null;
+        state.eliminatedAnswers = [];
+        state.pendingPowerup = null;
+        state.lastQuizQuestionId = q.id;
+      }
+
+      // Engine-provided eliminatedAnswers override local (keeps fifty powerup in sync)
+      if (Array.isArray(msg.eliminatedAnswers)) {
+        state.eliminatedAnswers = msg.eliminatedAnswers;
+      }
+
+      // Sync pending powerup with server powerup state — if the server says a
+      // powerup is no longer available and we haven't marked it locally, sync.
+      if (msg.myPowerups) {
+        for (const p of ['double', 'fifty', 'freeze']) {
+          if (msg.myPowerups[p] === false) {
+            state.powerupsUsed[p] = true;
+          }
+        }
+      }
+
+      // Header line: "Question X of Y"
+      const headerText = (msg.currentQuestion != null && msg.totalQuestions)
+        ? 'Question ' + (msg.currentQuestion + 1) + ' of ' + msg.totalQuestions
+        : '';
+
+      if (msg.phase === 'countdown') {
+        timerContainer.style.display = 'none';
+        timerText.textContent = 'Get ready...';
+        questionEl.textContent = headerText || 'Get ready!';
+        grid.innerHTML = '';
+        powerupsEl.style.display = 'none';
+      } else if (msg.phase === 'between') {
+        timerContainer.style.display = 'none';
+        timerText.textContent = '';
+        questionEl.textContent = 'Next up: ' + headerText;
+        grid.innerHTML = '';
+        powerupsEl.style.display = 'none';
+      } else if (msg.phase === 'question') {
+        questionEl.textContent = (headerText ? headerText + ' — ' : '') + (q && q.text ? q.text : '');
 
         // Save question state for re-renders (e.g. after answer selection)
         state._lastQuestion = q;
@@ -1395,8 +1444,7 @@
         // Answers
         const labels = ['A', 'B', 'C', 'D'];
         const classes = ['answer-a', 'answer-b', 'answer-c', 'answer-d'];
-        const answers = q.answers || [];
-        const grid = document.getElementById('quizAnswers');
+        const answers = (q && q.answers) || [];
         grid.innerHTML = answers.map((a, i) => {
           let cls = 'answer-btn ' + classes[i];
           if (state.selectedAnswer === i) cls += ' selected';
@@ -1407,27 +1455,27 @@
         }).join('');
 
         // Powerups
-        document.getElementById('quizPowerups').style.display = state.selectedAnswer === null ? 'flex' : 'none';
+        powerupsEl.style.display = state.selectedAnswer === null ? 'flex' : 'none';
         updatePowerupBtns();
 
       } else if (msg.phase === 'reveal') {
         timerContainer.style.display = 'none';
         timerText.textContent = '';
+        questionEl.textContent = (headerText ? headerText + ' — ' : '') + (q && q.text ? q.text : '');
 
-        const q = msg.question || {};
         const labels = ['A', 'B', 'C', 'D'];
         const classes = ['answer-a', 'answer-b', 'answer-c', 'answer-d'];
-        const answers = q.answers || [];
-        const grid = document.getElementById('quizAnswers');
+        const answers = (q && q.answers) || [];
         grid.innerHTML = answers.map((a, i) => {
           let cls = 'answer-btn ' + classes[i];
           if (i === msg.correctIndex) cls += ' correct';
           else if (state.selectedAnswer === i) cls += ' incorrect';
+          if (state.eliminatedAnswers.includes(i) && i !== msg.correctIndex) cls += ' eliminated';
           return '<button class="' + cls + '" disabled>' +
             '<strong>' + labels[i] + '.</strong> ' + escapeHtml(a) + '</button>';
         }).join('');
 
-        document.getElementById('quizPowerups').style.display = 'none';
+        powerupsEl.style.display = 'none';
       }
 
       if (msg.score != null) {
@@ -1438,31 +1486,62 @@
 
     function selectAnswer(index) {
       if (state.selectedAnswer !== null) return;
+      if (state.eliminatedAnswers.includes(index)) return;
       state.selectedAnswer = index;
       // Send the answer text (not index) so the engine can compare against correct_answer string
       const answerId = state._lastQuestion && state._lastQuestion.answers
         ? state._lastQuestion.answers[index]
         : index;
-      send({ type: 'GAME_ACTION', action: { type: 'answer', answerId } });
-      // Re-render to show selected state
-      renderQuizState({ phase: 'question', question: state._lastQuestion, timeLeft: state._lastTimeLeft, timeTotal: state._lastTimeTotal });
+      const action = { type: 'answer', answerId };
+      // Attach any pending powerup (double/freeze) to the submission
+      if (state.pendingPowerup && state.pendingPowerup !== 'fifty') {
+        action.powerupType = state.pendingPowerup;
+      }
+      send({ type: 'GAME_ACTION', action });
+
+      // Immediately reflect the selection in the DOM (server will confirm shortly)
+      const btns = document.querySelectorAll('#quizAnswers .answer-btn');
+      btns.forEach((btn, i) => {
+        btn.disabled = true;
+        if (i === index) btn.classList.add('selected');
+      });
+      document.getElementById('quizPowerups').style.display = 'none';
     }
 
     function usePowerup(type) {
       if (state.powerupsUsed[type]) return;
-      state.powerupsUsed[type] = true;
-      send({ type: 'GAME_ACTION', action: { type: 'answer', powerupType: type } });
+      if (state.selectedAnswer !== null) return;
+
+      if (type === 'fifty') {
+        // Fifty is activated immediately on the server — it trims the answer list
+        // via the next view update (eliminatedAnswers).
+        state.powerupsUsed.fifty = true;
+        send({ type: 'GAME_ACTION', action: { type: 'useFifty' } });
+      } else {
+        // Double / freeze are tracked locally and attached to the answer on submit
+        state.pendingPowerup = type;
+        state.powerupsUsed[type] = true;
+      }
       updatePowerupBtns();
     }
 
     function updatePowerupBtns() {
-      ['double', '5050', 'freeze'].forEach(p => {
-        const btn = document.getElementById('pw' + (p === 'double' ? 'Double' : p === '5050' ? '5050' : 'Freeze'));
+      for (const [p, btnId] of Object.entries(QUIZ_POWERUP_BTNS)) {
+        const btn = document.getElementById(btnId);
+        if (!btn) continue;
         if (state.powerupsUsed[p]) {
           btn.disabled = true;
           btn.classList.add('used');
+        } else {
+          btn.disabled = false;
+          btn.classList.remove('used');
         }
-      });
+        if (state.pendingPowerup === p) {
+          btn.classList.add('selected');
+        } else {
+          btn.classList.remove('selected');
+        }
+      }
     }
 
     // --- Spy ---

--- a/src/engine/games/quiz.js
+++ b/src/engine/games/quiz.js
@@ -1,15 +1,6 @@
 // Small Hours - Quiz / Trivia Game
 import { fetchQuestions } from '../../fetcher/cached-fetcher.js';
 
-function shuffleArray(arr) {
-  const shuffled = [...arr];
-  for (let i = shuffled.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
-  }
-  return shuffled;
-}
-
 /**
  * Deterministic shuffle seeded by an integer.
  * Ensures all viewers (host + players) see the same answer order for a given question.
@@ -87,6 +78,8 @@ const quiz = {
       scores,
       streaks,
       powerups,
+      // { [playerId]: questionIndex } — tracks which question fifty was activated on
+      fiftyActivatedOn: {},
       questionStartTime: null,
       round: 0,
     };
@@ -109,6 +102,7 @@ const quiz = {
       }
 
       let newPowerups = state.powerups;
+      let newFiftyActivatedOn = state.fiftyActivatedOn || {};
       if (powerupType) {
         const playerPowerups = state.powerups[playerId];
         if (!playerPowerups || !playerPowerups[powerupType]) {
@@ -124,6 +118,9 @@ const quiz = {
             [powerupType]: false,
           },
         };
+        if (powerupType === 'fifty') {
+          newFiftyActivatedOn = { ...newFiftyActivatedOn, [playerId]: state.currentQuestion };
+        }
       }
 
       const newAnswers = {
@@ -140,6 +137,7 @@ const quiz = {
           ...state,
           answers: newAnswers,
           powerups: newPowerups,
+          fiftyActivatedOn: newFiftyActivatedOn,
         },
         events: [
           {
@@ -148,6 +146,42 @@ const quiz = {
             usedPowerup: powerupType || null,
           },
         ],
+      };
+    },
+
+    useFifty(state, { playerId }) {
+      if (state.phase !== 'question') {
+        return {
+          state,
+          events: [{ type: 'error', playerId, message: 'Not in question phase' }],
+        };
+      }
+      if (state.answers[playerId]) {
+        return {
+          state,
+          events: [{ type: 'error', playerId, message: 'Already answered' }],
+        };
+      }
+      const playerPowerups = state.powerups[playerId];
+      if (!playerPowerups || !playerPowerups.fifty) {
+        return {
+          state,
+          events: [{ type: 'error', playerId, message: 'Powerup fifty not available' }],
+        };
+      }
+      return {
+        state: {
+          ...state,
+          powerups: {
+            ...state.powerups,
+            [playerId]: { ...playerPowerups, fifty: false },
+          },
+          fiftyActivatedOn: {
+            ...(state.fiftyActivatedOn || {}),
+            [playerId]: state.currentQuestion,
+          },
+        },
+        events: [{ type: 'powerup_activated', playerId, powerupType: 'fifty' }],
       };
     },
 
@@ -277,23 +311,8 @@ const quiz = {
       const question = state.questions[state.currentQuestion];
       if (question) {
         const allAnswers = [question.correct_answer, ...question.incorrect_answers];
-
-        let answers;
-        // Apply fifty-fifty: remove 2 incorrect answers
-        const playerAnswer = state.answers[playerId];
-        const usedFifty =
-          (playerAnswer && playerAnswer.powerupType === 'fifty') ||
-          (state.powerups[playerId] && !state.powerups[playerId].fifty && state.phase === 'question');
-
         // Use seeded shuffle so host and all players see the same answer order
-        if (usedFifty && state.phase === 'question') {
-          const incorrect = [...question.incorrect_answers];
-          // Keep only 1 incorrect answer
-          const kept = incorrect.slice(0, 1);
-          answers = seededShuffle([question.correct_answer, ...kept], state.currentQuestion);
-        } else {
-          answers = seededShuffle(allAnswers, state.currentQuestion);
-        }
+        const answers = seededShuffle(allAnswers, state.currentQuestion);
 
         base.question = {
           id: question.id,
@@ -302,6 +321,24 @@ const quiz = {
           category: question.category,
           difficulty: question.difficulty,
         };
+
+        // Compute eliminatedAnswers for this player (fifty-fifty powerup).
+        // Fifty is per-question: only eliminate if the player activated fifty
+        // on this specific question (tracked via fiftyActivatedOn).
+        const fiftyOn = state.fiftyActivatedOn && state.fiftyActivatedOn[playerId];
+        const usedFiftyHere = fiftyOn === state.currentQuestion;
+
+        if (usedFiftyHere) {
+          // Eliminate all incorrect answers except the first one.
+          // Use the same seeded shuffle so the kept incorrect answer is deterministic.
+          const shuffledIncorrect = seededShuffle(question.incorrect_answers, state.currentQuestion);
+          const keepIncorrect = shuffledIncorrect[0];
+          base.eliminatedAnswers = answers
+            .map((a, i) => (a === question.correct_answer || a === keepIncorrect ? -1 : i))
+            .filter(i => i !== -1);
+        } else {
+          base.eliminatedAnswers = [];
+        }
 
         base.hasAnswered = !!state.answers[playerId];
       }

--- a/tests/engine/quiz.test.js
+++ b/tests/engine/quiz.test.js
@@ -389,7 +389,7 @@ describe('Quiz - view filtering', () => {
     expect(view.hasAnswered).toBe(false);
   });
 
-  it('fifty-fifty reduces answers to 2 during question phase', () => {
+  it('fifty-fifty leaves 4 answers but marks 2 as eliminated during question phase', () => {
     const game = makeGame(['p1']);
     const g1 = toQuestion(game);
     const { game: g2 } = processAction(g1, {
@@ -399,9 +399,88 @@ describe('Quiz - view filtering', () => {
       powerupType: 'fifty',
     });
     const view = getView(g2, 'p1');
-    // After fifty-fifty: correct + 1 incorrect = 2 answers
-    expect(view.question.answers).toHaveLength(2);
+    // Answer list is always 4 — eliminated indices point to 2 of them.
+    expect(view.question.answers).toHaveLength(4);
     expect(view.question.answers).toContain(Q1.correct_answer);
+    expect(view.eliminatedAnswers).toHaveLength(2);
+    // The correct answer must not be eliminated
+    const correctIdx = view.question.answers.indexOf(Q1.correct_answer);
+    expect(view.eliminatedAnswers).not.toContain(correctIdx);
+  });
+
+  it('view returns empty eliminatedAnswers when fifty not used', () => {
+    const game = makeGame(['p1']);
+    const g1 = toQuestion(game);
+    const view = getView(g1, 'p1');
+    expect(view.eliminatedAnswers).toEqual([]);
+  });
+
+  it('useFifty action activates fifty without recording an answer', () => {
+    const game = makeGame(['p1']);
+    const g1 = toQuestion(game);
+    const { game: g2, events } = processAction(g1, {
+      type: 'useFifty',
+      playerId: 'p1',
+    });
+    // Powerup is consumed
+    expect(g2.state.powerups.p1.fifty).toBe(false);
+    // No answer was recorded — player can still answer
+    expect(g2.state.answers.p1).toBeUndefined();
+    expect(events[0].type).toBe('powerup_activated');
+    expect(events[0].powerupType).toBe('fifty');
+    // View now shows eliminated indices
+    const view = getView(g2, 'p1');
+    expect(view.question.answers).toHaveLength(4);
+    expect(view.eliminatedAnswers).toHaveLength(2);
+  });
+
+  it('useFifty rejects if player already answered', () => {
+    const game = makeGame(['p1']);
+    const g1 = toQuestion(game);
+    const { game: g2 } = processAction(g1, {
+      type: 'answer',
+      playerId: 'p1',
+      answerId: Q1.correct_answer,
+    });
+    const { events } = processAction(g2, { type: 'useFifty', playerId: 'p1' });
+    expect(events[0].type).toBe('error');
+    expect(events[0].message).toMatch(/already answered/i);
+  });
+
+  it('useFifty rejects if fifty not available', () => {
+    const game = makeGame(['p1']);
+    const g1 = toQuestion(game);
+    const { game: g2 } = processAction(g1, { type: 'useFifty', playerId: 'p1' });
+    const { events } = processAction(g2, { type: 'useFifty', playerId: 'p1' });
+    expect(events[0].type).toBe('error');
+    expect(events[0].message).toMatch(/not available/i);
+  });
+
+  it('useFifty rejects outside question phase', () => {
+    const game = makeGame(['p1']);
+    // Still in countdown
+    const { events } = processAction(game, { type: 'useFifty', playerId: 'p1' });
+    expect(events[0].type).toBe('error');
+    expect(events[0].message).toMatch(/not in question/i);
+  });
+
+  it('answer after useFifty still works (player can answer post-fifty)', () => {
+    const game = makeGame(['p1']);
+    const g1 = toQuestion(game);
+    const g2 = processAction(g1, { type: 'useFifty', playerId: 'p1' }).game;
+    // Get the view to find the available (non-eliminated) answer set
+    const view = getView(g2, 'p1');
+    // Player picks the correct answer
+    const { game: g3, events } = processAction(g2, {
+      type: 'answer',
+      playerId: 'p1',
+      answerId: Q1.correct_answer,
+    });
+    expect(g3.state.answers.p1).toBeDefined();
+    expect(g3.state.answers.p1.answerId).toBe(Q1.correct_answer);
+    expect(events[0].type).toBe('answer_submitted');
+    // eliminatedAnswers still respected post-answer
+    expect(view.eliminatedAnswers).toHaveLength(2);
   });
 
   it('reveals correctAnswer during reveal phase', () => {


### PR DESCRIPTION
The quiz game had several bugs that broke it from question 2 onwards and
made powerups unusable:

- Player's selectedAnswer and eliminatedAnswers persisted across questions,
  so from question 2 onwards every answer button was rendered disabled
  ("already answered") and users literally could not play past Q1.
- The 50/50 powerup sent 'powerupType: 5050' while the engine expected
  'fifty' — the powerup never worked at all.
- Clicking any powerup called send({type:'answer', powerupType:type}) with
  no answerId, which recorded an empty answer on the server and locked the
  player out of submitting a real answer.
- The view reduced the answer list to 2 entries when fifty was used, which
  meant the host display (which piggybacks the first player's view) also
  lost answers — and once fifty was consumed, the reduction stuck across
  every subsequent question.
- renderQuiz on host and renderQuizState on player rendered nothing during
  the countdown and between phases, leaving the screen blank or stale.

Fixes:

- Engine: add useFifty action so fifty can be activated without submitting
  an answer; track fiftyActivatedOn[playerId] so the effect is strictly
  per-question; view always returns all 4 answers and a separate
  eliminatedAnswers index array.
- Player: reset selectedAnswer / eliminatedAnswers / pendingPowerup when a
  new question.id arrives; track pendingPowerup locally for double/freeze
  and attach it to the answer on submit; send useFifty for 50/50; rename
  '5050' -> 'fifty' throughout; add countdown and between phase renders;
  show "Question X of Y" header.
- Host: render countdown and between phases; show "Question X of Y" in the
  round-info header.
- Tests: replace the "fifty reduces to 2" test with "keeps 4, marks 2
  eliminated"; add 6 new tests covering useFifty happy path, errors,
  post-activation answering.